### PR TITLE
feat(auth): add POST /api/auth/reset-password endpoint

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -124,7 +124,65 @@ export const login = async (req, res) => {
     }
 };
 
+export const resetPassword = async (req, res) => {
+    try {
+        const { name, email, newPassword } = req.body || {};
+
+        // Basic field validation
+        if (
+            typeof name !== 'string' ||
+            typeof email !== 'string' ||
+            typeof newPassword !== 'string' ||
+            !name.trim() ||
+            !email.trim() ||
+            !newPassword
+        ) {
+            return res.status(400).json({
+                success: false,
+                message: '缺少必要欄位',
+                code: 'INVALID_REQUEST',
+            });
+        }
+
+        // Minimal password policy — keep aligned with frontend rule (>=8)
+        if (newPassword.length < 8) {
+            return res.status(400).json({
+                success: false,
+                message: '密碼長度需至少 8 個字元',
+                code: 'WEAK_PASSWORD',
+            });
+        }
+
+        const user = await UserService.findByEmail(email.trim());
+
+        // Verify identity by matching name (trimmed, exact match).
+        // We deliberately return the SAME response for "user not found" and
+        // "name mismatch" so the endpoint cannot be abused for email enumeration.
+        if (!user || user.name !== name.trim()) {
+            return res.status(400).json({
+                success: false,
+                message: '姓名或電子郵件不正確',
+                code: 'RESET_FAILED',
+            });
+        }
+
+        await UserService.updateUser(user.id, { password: newPassword });
+
+        return res.status(200).json({
+            success: true,
+            message: '密碼已更新',
+        });
+    } catch (error) {
+        return res.status(500).json({
+            success: false,
+            message: error.message || '伺服器發生錯誤',
+            code: 'INTERNAL_ERROR',
+        });
+    }
+};
+
 export default {
     register,
     login,
+    resetPassword,
 };

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,9 +1,10 @@
 import express from 'express';
-import { register, login } from '../controllers/authController.js';
+import { register, login, resetPassword } from '../controllers/authController.js';
 
 const router = express.Router();
 
 router.post('/register', register);
 router.post('/login', login);
+router.post('/reset-password', resetPassword);
 
 export default router;

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -347,7 +347,81 @@ describe('PATCH /api/user/profile', () => {
     });
 });
 
-// Route existence tests
+// ============================================
+// Section: Forgot Password / Reset Password
+// ============================================
+
+describe('POST /api/auth/reset-password', () => {
+    const validResetBody = {
+        name: '王小明',
+        email: 'test@example.com',
+        newPassword: 'newPassword123',
+    };
+
+    test('endpoint exists (does not return 404)', async () => {
+        const res = await executeRequest({
+            method: 'POST',
+            url: '/api/auth/reset-password',
+            body: {},
+        });
+        expect(res.statusCode).not.toBe(404);
+    });
+
+    test('returns success:false with 400 when fields missing', async () => {
+        const res = await executeRequest({
+            method: 'POST',
+            url: '/api/auth/reset-password',
+            body: { email: 'test@example.com' },
+        });
+        expect(res.statusCode).toBe(400);
+        expect(res._isJSON()).toBe(true);
+        const data = res._getJSONData();
+        expect(data).toHaveProperty('success', false);
+        expect(data).toHaveProperty('code', 'INVALID_REQUEST');
+        expect(data).toHaveProperty('message');
+    });
+
+    test('returns success:false with 400 when newPassword is too short', async () => {
+        const res = await executeRequest({
+            method: 'POST',
+            url: '/api/auth/reset-password',
+            body: { ...validResetBody, newPassword: 'short' },
+        });
+        expect(res.statusCode).toBe(400);
+        const data = res._getJSONData();
+        expect(data.success).toBe(false);
+        expect(data.code).toBe('WEAK_PASSWORD');
+    });
+
+    test('returns RESET_FAILED for non-existent user (email enumeration safe)', async () => {
+        const res = await executeRequest({
+            method: 'POST',
+            url: '/api/auth/reset-password',
+            body: {
+                name: 'Nobody',
+                email: `does-not-exist-${Date.now()}@example.com`,
+                newPassword: 'newPassword123',
+            },
+        });
+        expect(res.statusCode).toBe(400);
+        const data = res._getJSONData();
+        expect(data.success).toBe(false);
+        expect(data.code).toBe('RESET_FAILED');
+        expect(data.message).toBe('姓名或電子郵件不正確');
+    });
+
+    test('response shape matches frontend contract on validation error', async () => {
+        const res = await executeRequest({
+            method: 'POST',
+            url: '/api/auth/reset-password',
+            body: {},
+        });
+        const data = res._getJSONData();
+        expect(Object.keys(data).sort()).toEqual(['code', 'message', 'success'].sort());
+    });
+});
+
+
 describe('API Route Existence', () => {
     test('/api/auth/register endpoint exists', async () => {
         const res = await executeRequest({


### PR DESCRIPTION
Implements the forgot-password backend per the iOS frontend spec: verify identity by (name + email) and update the user's password.

- New controller `resetPassword` in src/controllers/authController.js
- Wire route POST /api/auth/reset-password in src/routes/auth.js
- Reuses UserService.updateUser (bcrypt hashing already handled there)
- Response shape matches the agreed contract:
    success: { success: true,  message: "密碼已更新" }                 (200)
    failure: { success: false, message, code }                          (400/500)
  Codes: INVALID_REQUEST | WEAK_PASSWORD | RESET_FAILED | INTERNAL_ERROR
- Email-enumeration safe: "user not found" and "name mismatch" both
  return the same RESET_FAILED response.
- Adds unit tests in tests/auth.test.js covering the contract.