### PR TITLE
fix(compose): correct backend healthcheck port (dev) + handle TLS sel…

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -74,12 +74,11 @@ services:
       inference:
         condition: service_healthy
     healthcheck:
+      # dev: https on 8442 (self-signed cert, so disable TLS verification)
       test:
         [
-          "CMD",
-          "node",
-          "-e",
-          "fetch('https://localhost:8443/api/alive').then(r => { if (!r.ok) process.exit(1) })",
+          "CMD-SHELL",
+          "NODE_TLS_REJECT_UNAUTHORIZED=0 node -e \"fetch('https://localhost:8442/api/alive').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))\"",
         ]
       interval: 15s
       timeout: 5s

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -72,12 +72,11 @@ services:
       inference:
         condition: service_healthy
     healthcheck:
+      # prod: https on 8443 (self-signed in container, terminated by nginx upstream)
       test:
         [
-          "CMD",
-          "node",
-          "-e",
-          "fetch('https://localhost:8443/api/alive').then(r => { if (!r.ok) process.exit(1) })",
+          "CMD-SHELL",
+          "NODE_TLS_REJECT_UNAUTHORIZED=0 node -e \"fetch('https://localhost:8443/api/alive').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))\"",
         ]
       interval: 15s
       timeout: 5s


### PR DESCRIPTION
…f-signed cert

Two bugs in the backend healthcheck across dev and prod compose files:

1. Dev healthcheck targeted port 8443, but the dev backend listens on 8442 (only prod exposes 8443). Result: connection refused, container marked unhealthy despite being fully functional.

2. Both healthchecks call `fetch('https://...')` against a self-signed in-container cert without `NODE_TLS_REJECT_UNAUTHORIZED=0`, so even with the right port the TLS handshake would have failed.

3. Bonus: the original promise chain had no `.catch()` handler. On rejection it relied on Node's unhandled-rejection exit behavior, which is brittle across versions. Switched to explicit `process.exit(r.ok ? 0 : 1)` plus `.catch(() => process.exit(1))` so the healthcheck deterministically returns the right exit code.

Also switched the test array form from CMD to CMD-SHELL so the inline env var assignment (`NODE_TLS_REJECT_UNAUTHORIZED=0 node -e ...`) parses correctly.