### PR TITLE
chore: container logs, Discord alerting, and token-usage capture

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -36,3 +36,13 @@ ANTHROPIC_API_KEY=
 # HTTPS certificate paths (certbot)
 # Certificate is saved at: /etc/letsencrypt/live/mindechoserver.com/fullchain.pem
 # Key is saved at:         /etc/letsencrypt/live/mindechoserver.com/privkey.pem
+
+# ── Monitoring & admin (see .plan/monitor-and-logs.md) ──────────────────────
+# Discord Incoming Webhook URL — backend posts warn/error alerts here in prod.
+# Leave blank to disable alerting (no-op in dev).
+DISCORD_ALERT_WEBHOOK_URL=
+# Comma-separated list of User.userId values granted admin access to /api/admin/*.
+# Empty → everyone receives 403 (safe default).
+ADMIN_USERNAMES=
+# Optional override for the prod log directory (Docker bind-mounted to ./logs/backend-prod).
+# LOG_DIR=/app/logs

--- a/.plan/monitor-and-logs.md
+++ b/.plan/monitor-and-logs.md
@@ -1,0 +1,309 @@
+# Plan — Monitoring, Logs, and Admin Data Visualization
+
+**Date:** 2026-05-01 (v3 — Option B + env-allowlist auth, all open questions resolved)
+**Branch (proposed):** `chore/monitor-logs-and-admin-dashboard`
+**Status:** PLAN ONLY — do not execute until Mulkooo approves
+**Supersedes:** previous draft `.plan/monitor-and-logs.md` (lost when `.plan/` was untracked)
+
+---
+
+## 0. Goal
+
+Three deliverables, one branch / one PR:
+
+1. **Discord webhook alerting** — outbound POSTs from prod backend to a Discord Incoming Webhook on warn/error.
+2. **Mounted, rotated container logs** — prod backend stdout/stderr captured to `./logs/backend-prod/` on the host with **daily rotation, 7-day retention** — using **Docker's built-in capabilities + a small entrypoint tee**, no in-app logging library.
+3. **Admin data dashboard** on the existing `test-frontend/` Vue app — three views over prod data: registered user list, LLM service stats (token usage, active time per user, etc.), per-user chat histories.
+
+Testing-stage assumption (provided by Mulkooo): every prod user is **hand-picked by the team and has consented to analysis**, so PII access from the dashboard is acceptable for the team. We still gate the admin endpoints behind a role check (defense in depth).
+
+---
+
+## 1. Current Context & Assumptions
+
+### Repo / branch state
+- `main` is clean as of 2026-05-01. `.plan/` exists but was never committed.
+- AGENTS.md hard rules apply: never touch `main`, only `docker-compose.test.yml` may be brought up by the agent, all work on a feature branch with PR.
+
+### Backend
+- Node 20 / Express 5 / Prisma 6, plain HTTP via `app.listen()` on `PROD_PORT` (default 8443) — TLS terminated by nginx upstream.
+- Auth: `src/middleware/auth.js` (JWT). **No role/admin field on `User` today.**
+- LLM call site: `src/utils/llm.js`. Token usage is **not currently persisted**. `Message.metadata` is `Json?`, available for use.
+
+### DB models touched by the dashboard
+- `User`, `ChatSession` (sessionId, chatbotType, provider, createdAt), `Message` (messageType, chatbotType, provider, content, **metadata Json?**, timestamp).
+
+### Test frontend
+- `test-frontend/` — Vue 3 + Vite + Pinia + vue-router. Existing views: Login, ChatLayout, ChatConversation, NewSession, SessionList. We extend it.
+
+### What's NOT in scope
+- Postgres / inference / dev container log mounting — deferred (Mulkooo's spec was prod backend only).
+- Postgres FATAL → Discord — deferred.
+- ELK/Loki pipeline — not on the immediate roadmap, so Docker-native logging is sufficient (see Option-B discussion in the conversation thread).
+
+---
+
+## 2. Approach (Option B — Docker-native logs + small app-side Discord alerter)
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│ prod backend container (mindecho_backend_prod)                     │
+│                                                                    │
+│  node src/server.js                                                │
+│      │                                                             │
+│      ├─ stdout/stderr  ──tee──► /app/logs/backend-prod-YYYY-MM-DD  │
+│      │                          .log  (mounted to ./logs/...)      │
+│      │                          rotated daily by entrypoint,       │
+│      │                          7-day retention by cleanup script  │
+│      │                                                             │
+│      └─ src/utils/alert.js (called from error middleware +         │
+│         unhandledRejection + uncaughtException) ──HTTP POST──►     │
+│                                                  Discord Webhook   │
+│             ├─ prod-only (NODE_ENV + DISCORD_ALERT_WEBHOOK_URL)    │
+│             ├─ severity = warn|error                               │
+│             ├─ 60 s dedupe ("↺ repeated N×" follow-up)             │
+│             ├─ 2 s min interval throttle                           │
+│             ├─ 50-msg / minute overflow cap                        │
+│             └─ honors HTTP 429 Retry-After                         │
+│                                                                    │
+│  GET /api/admin/*  (NEW, role=ADMIN required)                      │
+│    ├─ /users            → user list + agg stats                    │
+│    ├─ /llm-stats        → token usage, active time, per-user agg   │
+│    └─ /users/:id/chats  → sessions + messages for one user         │
+└────────────────────────────────────────────────────────────────────┘
+                          ▲
+                          │  fetch (Bearer JWT, role=ADMIN)
+                          │
+┌────────────────────────────────────────────────────────────────────┐
+│ test-frontend (Vue 3) — NEW routes under /admin/*                  │
+│   /admin/users      ← AdminUsersView.vue                           │
+│   /admin/llm        ← AdminLlmStatsView.vue                        │
+│   /admin/users/:id  ← AdminUserChatsView.vue                       │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+### Why no pino / Logstash
+- Pino: nice but solves "structured JSON logging" — we don't have an ELK/Loki sink, so the structure is wasted.
+- Logstash: ingests/transforms logs *after* they're produced; not a logger, not what we need.
+- Docker's `json-file` driver already rotates by size+count for free; combined with a stdout `tee` we get a human-readable file under `./logs/` AND `docker logs` keeps working.
+
+---
+
+## 3. Step-by-Step Plan
+
+### Phase 0 — Branch + scaffolding
+1. `git checkout main && git pull`
+2. `git checkout -b chore/monitor-logs-and-admin-dashboard`
+3. Create `logs/.gitignore` containing `*` and `!.gitignore` so the dir exists in git but its contents are ignored.
+
+### Phase 1 — Logging (Docker-native, prod backend only)
+
+**Files to add / change:**
+- `scripts/entrypoint-prod.sh` (NEW) — wraps the existing CMD. Uses a small Node helper that owns the file handle so we get **proper midnight rotation** without needing a container restart:
+  ```sh
+  #!/bin/sh
+  set -e
+  export LOG_DIR="${LOG_DIR:-/app/logs}"
+  mkdir -p "$LOG_DIR"
+  # Pipe app stdout+stderr through the rotator (which writes to dated files
+  # AND echoes to its own stdout, so `docker logs` keeps working).
+  exec node src/server.js 2>&1 | node scripts/log-rotator.js
+  ```
+- `scripts/log-rotator.js` (NEW) — ~40 lines, no deps:
+  - Reads `LOG_DIR` env, opens `backend-prod-<UTC-date>.log` for append.
+  - On every newline of stdin: write to current file AND `process.stdout.write` (so Docker still captures).
+  - `setInterval(checkDateRollover, 30_000)`: when the UTC date changes, `fs.close` the old handle, open the new dated file, `fs.symlinkSync(newName, LOG_DIR/current.log)` (force-replace), and run a 7-day cleanup: `fs.readdir` → drop any `backend-prod-*.log` whose date is older than 7 days.
+  - Handles SIGTERM/SIGINT cleanly: flush, close, exit 0.
+- `Dockerfile` (prod stage) → `COPY scripts/entrypoint-prod.sh scripts/log-rotator.js /app/scripts/`, `chmod +x` the entrypoint, `ENTRYPOINT ["/app/scripts/entrypoint-prod.sh"]`.
+
+**Test plan (Phase 1):**
+- Smoke test under `docker-compose.test.yml`: bring up backend, hit a few endpoints, verify `./logs/backend-prod/backend-prod-YYYY-MM-DD.log` exists with the request lines and `current.log` symlink resolves.
+
+### Phase 2 — Discord alerter (small app-side helper)
+
+**Files to add / change:**
+- `src/utils/alert.js` (NEW) — `discordAlert({ level, message, error, context })`:
+  - No-op when `NODE_ENV !== 'production'` OR `!process.env.DISCORD_ALERT_WEBHOOK_URL`.
+  - Maintains an in-memory map: `fingerprint → { count, firstSeenAt }`.
+    - Fingerprint = sha1(`level | message | error?.code | error?.name`).
+    - On first occurrence in 60 s → POST immediately.
+    - Repeat occurrences → suppressed; at end of window POST single follow-up `↺ repeated N×`.
+  - Throttle: min 2 s between sends; queue up to 50 msgs/min; on overflow drop with one-time `⚠ alert overflow, dropping` notice.
+  - Respects HTTP `429` `Retry-After` (sleep, then resume).
+  - Embed: title = level emoji + UPPERCASE level, description = message (4000-char trim), fields = container hostname, ISO timestamp, optional `context` keys.
+- `src/middleware/errorHandler.js` (NEW or extend existing) — catches Express errors, calls `console.error` (so it lands in the tee'd file) AND `discordAlert({ level: 'error', ... })` for 5xx.
+- `src/server.js` — register `process.on('unhandledRejection')` and `process.on('uncaughtException')` → `discordAlert({ level: 'error', ... })`, then re-throw / exit per current Node best practice.
+
+**Test plan (Phase 2):**
+- `tests/unit/utils/alert.test.js` — mock `fetch`; assert:
+  - dev mode: zero calls
+  - prod mode: first call sent, dedupe window suppresses repeats, follow-up `↺ repeated N×` fires
+  - throttle: rapid bursts → spaced ≥ 2 s
+  - overflow: > 50/min → drop + one-shot overflow notice
+  - 429 with `Retry-After: 3` → next send delayed ≥ 3 s
+- **Must not hit the real webhook** (use a mock URL + `fetch` stub).
+
+### Phase 3 — Compose wiring (prod only)
+
+**Files to change:**
+- `docker-compose.prod.yml`:
+  ```yaml
+  backend:
+    volumes:
+      - ./logs/backend-prod:/app/logs
+    environment:
+      LOG_DIR: /app/logs
+      DISCORD_ALERT_WEBHOOK_URL: ${DISCORD_ALERT_WEBHOOK_URL:-}
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "7"
+  ```
+- `.env.sample` → document `DISCORD_ALERT_WEBHOOK_URL=` (blank).
+- `README.md` → short "Operational logs & alerting" section.
+
+**Verification (Phase 3):**
+- Cannot be run by the agent (AGENTS.md forbids `up` against prod compose). Mulkooo to verify by:
+  1. `docker compose -f docker-compose.prod.yml up -d --no-deps --force-recreate backend`
+  2. Confirm `./logs/backend-prod/backend-prod-YYYY-MM-DD.log` appears
+  3. Trigger a 5xx → confirm Discord embed lands
+
+### Phase 4 — Token usage capture (prerequisite for the LLM-stats dashboard)
+
+**Files to change:**
+- `src/utils/llm.js` — when persisting the model response `Message`, fill `metadata`:
+  ```json
+  { "tokens": { "input": N, "output": N, "total": N },
+    "model": "<provider-model-name>",
+    "latencyMs": N }
+  ```
+  Pull from `usageMetadata` (Gemini) / `usage` (Anthropic). If absent, store `null` — never crash.
+- No schema migration; `Message.metadata` is already `Json?`.
+
+**Test plan (Phase 4):**
+- Unit-test the metadata-extraction helper for both providers (mock provider responses).
+- No backfill of historical messages — dashboard shows "n/a" for older rows. (Open question Q3.)
+
+### Phase 5 — Admin auth + admin API
+
+**No schema migration.** Auth uses an env-based username allowlist, since the `test-frontend/` is dev-team-only by design and Mulkooo hand-curates accounts directly in the DB.
+
+**Files to add:**
+- `src/middleware/requireAdmin.js` (NEW) — runs after `authenticate`:
+  ```js
+  const ADMIN_SET = new Set(
+    (process.env.ADMIN_USERNAMES || '').split(',').map(s => s.trim()).filter(Boolean)
+  );
+  export const requireAdmin = (req, res, next) =>
+    ADMIN_SET.has(req.user?.userId)
+      ? next()
+      : res.status(403).json({ message: 'Forbidden — admin only' });
+  ```
+  - Uses `req.user.userId` (the `User.userId` field, e.g. `prof_peiyu`), populated by the existing `authenticate` middleware.
+  - Empty allowlist → all requests 403 (safe default if env is missing).
+- `src/controllers/adminController.js` (NEW) — three handlers:
+  - `listUsers` — id, userId, email, name, isActive, lastLoginAt, createdAt, dataAnalysisConsent, plus aggregates: `messageCount`, `sessionCount`, `lastMessageAt`.
+  - `llmStats` — global + per-user: total input/output/total tokens, request count, by `chatbotType`, by `provider`, by day (last 30 d). **"Weekly active time" per user** = sum across the 7 weekdays of `(last_message_ts_that_day - first_message_ts_that_day)`, computed over the last 30 d (or "current ISO week" — confirm with Mulkooo at impl time; defaulting to current ISO week as the more natural reading of "weekly").
+  - `getUserChats` — `:userId`, sessions ordered by `updatedAt desc` with paginated messages (page size 50).
+- `src/routes/admin.js` (NEW) — `GET /api/admin/users`, `/api/admin/llm-stats`, `/api/admin/users/:userId/chats`. Mount in `src/routes/main.js` behind `authenticate, requireAdmin`.
+
+**Env config:**
+- `ADMIN_USERNAMES=prof_peiyu,prof_zhixun,prof_peihsuan,yuming,jinghan,yishin,yuchen` — set in prod `.env` only. Documented in `.env.sample` as blank (don't commit real names).
+
+**Test plan (Phase 5):**
+- `tests/integration/admin.test.js` — set `ADMIN_USERNAMES=alice` for the test, seed two users (alice + bob), assert:
+  - bob (non-admin) → 403 on every `/api/admin/*`
+  - alice (admin) → 200, response shape matches contract
+  - llmStats sums match seeded fixtures
+  - empty `ADMIN_USERNAMES` → everyone 403
+
+### Phase 6 — Test-frontend admin views
+
+**Files to add:**
+- `test-frontend/src/views/AdminUsersView.vue` — sortable table (name / email / lastLoginAt / sessions / messages / lastMessageAt / consent / active). Click row → `/admin/users/:id`.
+- `test-frontend/src/views/AdminLlmStatsView.vue` — KPI cards (total tokens 30 d, total requests 30 d, active users 30 d) + per-user table + tiny inline-SVG sparkline (no chart lib).
+- `test-frontend/src/views/AdminUserChatsView.vue` — left pane: session list; right pane: message thread; collapsible metadata row under each MODEL message.
+- `test-frontend/src/api/admin.js` — fetch wrapper using existing auth store's bearer token.
+- `test-frontend/src/router/index.js` — add three routes; reuse existing auth guard. The Admin nav link is **always shown** (test-frontend is dev-only); if the JWT isn't in the allowlist, the API returns 403 and the view shows a friendly "Not in admin allowlist" message.
+- `test-frontend/src/views/ChatLayout.vue` (or wherever the nav lives) — add static "Admin" link.
+
+**Styling:** plain CSS in `test-frontend/src/styles/admin.css`. No new npm deps in the frontend.
+
+**Test plan (Phase 6):**
+- Manual smoke test via `vite preview` against `docker-compose.test.yml` seeded with admin + sample data.
+- Add `scripts/seed-admin-fixture.js` for the seed.
+
+### Phase 7 — Open PR
+- Push branch, open PR titled `chore: container logs, Discord alerting, and admin data dashboard`.
+- PR body: three deliverables, the Phase 3 manual verification steps, deferred items.
+
+---
+
+## 4. Files Likely to Change / Add
+
+| Path | Change |
+|---|---|
+| `scripts/entrypoint-prod.sh` | NEW |
+| `scripts/log-rotator.js` | NEW (~40 lines, no deps; midnight rotation + 7-day cleanup) |
+| `Dockerfile` (prod stage) | use new entrypoint |
+| `src/utils/alert.js` | NEW |
+| `src/middleware/errorHandler.js` | NEW or extend |
+| `src/utils/llm.js` | metadata capture (tokens, model, latency) |
+| `src/server.js` | unhandled handlers + alerter wiring |
+| `src/middleware/requireAdmin.js` | NEW (env-allowlist) |
+| `src/controllers/adminController.js` | NEW |
+| `src/routes/admin.js` | NEW |
+| `src/routes/main.js` | wire admin routes |
+| `docker-compose.prod.yml` | bind mount + json-file driver + env |
+| `.env.sample`, `README.md` | docs (`ADMIN_USERNAMES`, `DISCORD_ALERT_WEBHOOK_URL`, `LOG_DIR`) |
+| `logs/.gitignore` | NEW |
+| `tests/unit/utils/alert.test.js` | NEW |
+| `tests/integration/admin.test.js` | NEW |
+| `test-frontend/src/views/Admin*.vue` (×3) | NEW |
+| `test-frontend/src/api/admin.js` | NEW |
+| `test-frontend/src/router/index.js` | + admin routes |
+| `test-frontend/src/styles/admin.css` | NEW |
+
+**Notably NOT changed** (vs v2 of this plan): no Prisma migration, no `User.role`, no `scripts/seed-admin-fixture.js`, no `scripts/promote-admin.js`. Admin membership is pure env config.
+
+---
+
+## 5. Tests / Validation
+
+- `npm test` — unit tests above must pass.
+- `npm run test:integration` under `docker-compose.test.yml` for the admin endpoints + log-file smoke test.
+- Manual (Mulkooo): bring up prod backend, confirm `./logs/backend-prod/backend-prod-YYYY-MM-DD.log` appears + rotates, trigger 5xx → Discord embed arrives.
+- Manual (Mulkooo): hit `/admin/users` in the browser as the seeded admin, confirm tables render and per-user chat history loads.
+
+---
+
+## 6. Risks, Tradeoffs, Open Questions
+
+**Risks**
+- **PII surface area.** Even with consent, the dashboard centralizes raw chat content. Mitigations: role gate, JWT-only access, no public route, read-only.
+- **Discord alert storms.** Mitigated by dedupe + throttle + overflow cap; watch first week.
+- **Log disk usage.** Tee'd file capped by the 7-day cleanup (~50 MB/day soft expectation = ~350 MB max). Docker's `json-file` driver (`max-size 50m, max-file 7`) is an independent safety net for stdout capture.
+- **Rotator process death.** If `scripts/log-rotator.js` crashes, the pipeline `node src/server.js | node log-rotator.js` exits, container exits, Docker restarts it. So a rotator bug becomes "container restart loop" not "silent log loss" — preferable failure mode. We'll add a `try/catch` around the rotator's date-check `setInterval` to avoid this.
+
+**Resolved decisions (from planning convo)**
+1. **Daily rotation:** in-process Node midnight rotator (`scripts/log-rotator.js`) — no container restart needed.
+2. **Alert threshold:** `warn` AND `error` both POST to Discord.
+3. **Token backfill:** old messages show "n/a"; no backfill, no re-asking providers.
+4. **Weekly active time per user:** sum across the 7 weekdays of `(last_msg_ts_that_day − first_msg_ts_that_day)`. Default scope = current ISO week; coder agent should make the time window configurable via query param if trivial.
+5. **Admin auth:** env allowlist `ADMIN_USERNAMES` (no Prisma migration, no `User.role` column, no seed script). Mulkooo will set:
+   ```
+   ADMIN_USERNAMES=prof_peiyu,prof_zhixun,prof_peihsuan,yuming,jinghan,yishin,yuchen
+   ```
+6. **Discord webhook URL:** Mulkooo will create the Incoming Webhook and set `DISCORD_ALERT_WEBHOOK_URL` in prod `.env` after the PR is reviewed. Agent never sees the secret.
+
+---
+
+## 7. Out of Scope (deferred)
+
+- Postgres prod container log mounting.
+- Dev / inference container logs.
+- Postgres FATAL → Discord.
+- Real charts library (Chart.js / ECharts).
+- Audit log of admin views (who looked at whose chats and when).
+- ELK/Loki pipeline (would warrant pino + Filebeat at that point).

--- a/.plan/scaling-plan-100-concurrent-users.md
+++ b/.plan/scaling-plan-100-concurrent-users.md
@@ -1,0 +1,496 @@
+# Implementation Plan: Scaling Mind Echo for ~100 Concurrent Users
+
+**Date**: 2026-04-08
+**Status**: Draft — pending review and modification
+
+---
+
+## Current Architecture Bottlenecks
+
+Current flow per chat message: **3 sequential LLM calls** (summary → knowledge selection → therapy response), single uvicorn worker, single Node.js backend, no streaming, no queuing, no rate limiting.
+
+```
+nginx → 1x Node.js backend → 1x Python FastAPI (1 worker) → 3x serial LLM API calls
+```
+
+Under 100 concurrent users, that's potentially **300 simultaneous LLM API calls** with no backpressure.
+
+### Identified Bottlenecks
+
+| Bottleneck | Severity | Detail |
+|-----------|----------|--------|
+| 3 sequential LLM calls per message | CRITICAL | Each call takes 2-15s. Total TTFR is the sum of all three. |
+| Single uvicorn worker | CRITICAL | `main.py` line 21 defaults to 1 worker process. |
+| Single backend container | HIGH | One Node.js process handles all concurrent connections. |
+| No streaming | HIGH | Client waits for entire LLM response (10-30s). |
+| New LLM client per request | MEDIUM | `gemini.py` and `anthropic.py` instantiate new clients every call — TLS overhead. |
+| No request queuing or backpressure | HIGH | 100 users = 300 simultaneous LLM API calls, no admission control. |
+| No rate limiting | MEDIUM | A single user can monopolize inference capacity. |
+| Nginx timeout 60s | MEDIUM | Under load, 3-step LLM calls can exceed 60s → 504. |
+| Duplicate PrismaClient instances | LOW | `chatService.js` and `llm.js` create separate instances instead of using the singleton from `database.js`. |
+| Postgres port exposed in prod | LOW | `docker-compose.prod.yml` line 79 still maps host port. |
+| Gzip not configured for JSON | LOW | `nginx.conf` has gzip on but `gzip_types` is commented out. |
+
+---
+
+## Phase 1: Quick Wins (1-2 days)
+
+### 1.1 SSE Streaming for Chat Responses → **moved to its own plan**
+
+**Status**: Extracted to `.plan/sse-message-streaming.md` because streaming requires
+close frontend/backend collaboration (LLM SDK → FastAPI → Node → nginx → Vue) and
+warrants its own design document and multi-PR sequence rather than living as a
+quick-win bullet. See that plan for full details. Phase 1 here remains otherwise
+unchanged; SSE is no longer a prerequisite for Phase 2.
+
+### 1.2 Reuse LLM Client Instances (Singleton)
+
+**Files**: `inference/src/providers/gemini.py`, `inference/src/providers/anthropic.py`
+
+**Action**: Move client instantiation to module level. Create once on import, reuse across requests.
+
+```python
+# gemini.py — module top level
+client = genai.Client(api_key=os.environ.get("GEMINI_API_KEY"))
+
+# anthropic.py — module top level
+client = anthropic.AsyncAnthropic(api_key=os.environ.get("ANTHROPIC_API_KEY"))
+```
+
+**Impact**: Eliminates TLS handshake overhead on every request. Significant under 100 concurrent users.
+
+**Risk**: Low.
+
+### 1.3 Fix Duplicate PrismaClient Instances
+
+**Files**: `src/services/chatService.js` (line 4), `src/utils/llm.js` (line 6)
+
+**Action**: Replace `const prisma = new PrismaClient()` with `import prisma from '../config/database.js'` in both files.
+
+**Impact**: Saves DB connection pool slots (each `new PrismaClient()` opens its own pool).
+
+**Risk**: Low.
+
+### 1.4 Increase Uvicorn Workers
+
+**File**: `inference/main.py` (line 21)
+
+**Action**: Change to `uvicorn.run("main:app", host="0.0.0.0", port=port, reload=False, workers=4)` (or set via env var `INFERENCE_WORKERS`).
+
+**Impact**: Multiple worker processes handle concurrent LLM calls in parallel. 4 workers is a good starting point for 4-8 core home server.
+
+**Risk**: Low. Memory increases linearly but knowledge index is small.
+
+### 1.5 Nginx: Enable Gzip + Increase Timeout
+
+**Files**: `nginx/nginx.conf`, `nginx/conf.d/default.conf`
+
+**Action**:
+- Uncomment `gzip_types` in `nginx.conf`:
+  ```
+  gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+  ```
+- Increase `proxy_read_timeout` to `120s` in `default.conf` for `/api/` location blocks
+
+**Impact**: Prevents 504s under load. Reduces bandwidth for JSON responses.
+
+**Risk**: Low.
+
+### 1.6 Add Backend Container Healthcheck
+
+**File**: `docker-compose.prod.yml`
+
+**Action**:
+```yaml
+healthcheck:
+  test: ["CMD", "node", "-e", "fetch('http://localhost:8443/api/alive').then(r => { if (!r.ok) process.exit(1) })"]
+  interval: 15s
+  timeout: 5s
+  retries: 3
+```
+
+**Impact**: Docker can detect and restart unhealthy backend containers. Essential for multi-replica setup in Phase 2.
+
+**Risk**: Low.
+
+---
+
+## Phase 2: Inference Layer Scaling (3-5 days)
+
+### 2.1 Parallelize/Optimize Knowledge Selection
+
+**File**: `inference/src/knowledge.py`
+
+**Action**:
+- When history < 2 messages, Step 0 (summary) is already skipped — ensure Step 1 starts immediately
+- Reduce `max_output_tokens` for summary to 128 (summaries are 2-4 sentences)
+- Consider running summary with a faster/cheaper model
+
+**Impact**: Shaves 1-3s off TTFR.
+
+**Risk**: Low.
+
+### 2.2 Concurrency Semaphore in Inference Service
+
+**File**: `inference/src/router.py`
+
+**Action**:
+```python
+import asyncio
+_llm_semaphore = asyncio.Semaphore(int(os.environ.get("MAX_CONCURRENT_LLM_CALLS", "20")))
+
+# Wrap each LLM call:
+async with _llm_semaphore:
+    result = await provider.generate(...)
+```
+
+**Impact**: Prevents 300 simultaneous API calls. Provides backpressure — excess requests wait instead of all failing.
+
+**Risk**: Medium — need to tune semaphore value. Too low starves throughput; too high triggers rate limits. Start at 20.
+
+### 2.3 Retry with Exponential Backoff
+
+**Files**: `inference/src/providers/gemini.py`, `inference/src/providers/anthropic.py`
+
+**Action**: Add `tenacity` library. Retry on 429/500/502/503, 3 attempts, exponential backoff from 1s. Do NOT retry on 400/auth errors.
+
+```python
+from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
+```
+
+**Dependency**: Add `tenacity` to `inference/pyproject.toml`.
+
+**Risk**: Low.
+
+### 2.4 Provider Fallback
+
+**File**: `inference/src/router.py`
+
+**Action**: If primary provider fails after retries, fall back to alternate provider. Normalize `max_tokens` between providers (Anthropic=1000 vs Gemini=8192 currently).
+
+**Impact**: Doubles effective availability.
+
+**Risk**: Medium — different model capabilities need normalization.
+
+### 2.5 Scale Backend to Multiple Replicas
+
+**File**: `docker-compose.prod.yml`
+
+**Action**:
+- Add `deploy: { replicas: 2 }` to backend service
+- Remove `container_name` (forces single instance)
+- Nginx upstream block:
+  ```nginx
+  upstream backend_pool {
+      server backend-prod:8443;
+  }
+  ```
+  Docker internal DNS round-robins across replicas.
+
+**Impact**: Doubles Node.js event loop capacity.
+
+**Dependency**: Phase 1.6 (healthcheck).
+
+**Risk**: Medium — must ensure no in-memory state (currently all state is in Postgres, so this is safe).
+
+### 2.6 Asynchronous Knowledge Selector (Pre-warmed Queue)
+
+**Files**: `inference/src/knowledge.py`, `inference/src/router.py`, new `inference/src/knowledge_queue.py`,
+`src/utils/llm.js` (Node side fetch path)
+
+**Idea**: Today Steps 0 (summary) and 1 (knowledge selection) run **synchronously
+in front of** Step 2 (the therapy reply). They add 1–4s of latency to every message
+even though their inputs (recent conversation history) are already known the moment
+the *previous* assistant reply completes.
+
+Instead, run Steps 0 + 1 **eagerly in the background** the moment the previous turn
+ends, and stash the result in a per-session queue keyed by `session_id`. When the
+next user message arrives, Step 2 first **tries to drain** a ready knowledge result
+from the queue:
+
+- **Cache hit** → use it immediately, skip Steps 0 + 1, go straight to Step 2.
+  TTFR drops by the full Step 0 + Step 1 cost (typically 1–4s).
+- **Cache miss** (queue empty, e.g. first message of a session, or user typed
+  faster than the background task completed) → fall back to the current synchronous
+  path.
+
+Drained entries are removed from the queue (single-shot use). Stale entries past a
+TTL (e.g. 60s) are discarded so we don't serve knowledge selected against
+out-of-date history.
+
+**Sketch**:
+```python
+# knowledge_queue.py
+from collections import defaultdict
+import asyncio, time
+
+_queues: dict[str, asyncio.Queue] = defaultdict(lambda: asyncio.Queue(maxsize=1))
+TTL_SECONDS = 60
+
+async def push(session_id: str, knowledge: str, history_hash: str):
+    # Drop the queue if full (keep newest)
+    q = _queues[session_id]
+    if q.full():
+        try: q.get_nowait()
+        except asyncio.QueueEmpty: pass
+    await q.put({"knowledge": knowledge, "history_hash": history_hash, "ts": time.time()})
+
+async def try_pop(session_id: str, expected_history_hash: str) -> str | None:
+    q = _queues[session_id]
+    try:
+        entry = q.get_nowait()
+    except asyncio.QueueEmpty:
+        return None
+    if time.time() - entry["ts"] > TTL_SECONDS:
+        return None  # discard stale
+    if entry["history_hash"] != expected_history_hash:
+        return None  # history changed since prefetch
+    return entry["knowledge"]
+```
+
+```python
+# router.py — at end of /generate after Step 2 completes
+asyncio.create_task(_prefetch_next_knowledge(session_id, updated_history))
+```
+
+**Cache key / invalidation**: hash of the conversation history that *would be*
+the input to Steps 0 + 1 on the next turn. If the user edits or deletes a message
+between turns the hash mismatches and we fall back. Per-session `Queue(maxsize=1)`
+keeps memory bounded.
+
+**Why a queue (size 1) and not a plain dict?** Using `asyncio.Queue` makes the
+producer/consumer hand-off trivially thread-safe under uvicorn's async event loop,
+and lets us optionally extend to maxsize > 1 later (e.g. pre-fetch multiple
+candidate knowledge bundles).
+
+**Multi-worker caveat**: with uvicorn workers > 1 (Phase 1.4 set this to 4), the
+in-memory queue is **per-process**. A user's next request may hit a different
+worker → cache miss. Acceptable trade-off (fallback is the existing path), or
+upgrade the queue to Redis (Phase 3.1 dependency) for cross-worker sharing.
+
+**Impact**: Removes 1–4s from TTFR on the **second message onward** of every
+session, which is the steady-state case. Combined with Phase 2.1 (smaller summary
+output) and 2.2 (semaphore), eligible TTFR contribution from the selector pipeline
+drops to near zero in the cache-hit path.
+
+**Dependency**: Phase 2.1 (cleaner Step 0/1 boundaries make prefetch simpler).
+Optional upgrade path: Phase 3.1 (Redis) for cross-worker sharing.
+
+**Risk**: Medium —
+- Wasted LLM calls when user abandons session right after a reply (background task
+  still runs). Mitigate with a short delay before kicking off the prefetch (e.g. 2s
+  after reply ends, only if user is still connected).
+- Cache-key drift if other code paths can mutate session history. Mitigate via
+  history hash + TTL.
+- Multi-worker miss rate. Acceptable; quantify after rollout, escalate to Redis if
+  hit rate is too low.
+
+---
+
+## Phase 3: Infrastructure (3-5 days)
+
+### 3.1 Add Redis + Rate Limiting
+
+**Files**: `docker-compose.prod.yml`, new `src/middleware/rateLimiter.js`
+
+**Action**:
+- Add Redis container:
+  ```yaml
+  redis:
+    image: redis:7-alpine
+    expose:
+      - "6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: always
+  ```
+- Install `express-rate-limit` + `rate-limit-redis`
+- Per-user: 10 messages/minute on chat endpoint
+- Global: 200 requests/minute across all users
+
+**Impact**: Prevents single user monopolizing inference capacity. Works across replicas.
+
+**Dependency**: Phase 2.5 (replicas).
+
+**Risk**: Low.
+
+### 3.2 BullMQ Job Queue (Optional)
+
+**Files**: New `src/queues/inferenceQueue.js`, modify `src/utils/llm.js`
+
+**Action**:
+- Enqueue inference requests as BullMQ jobs instead of direct `fetch()`
+- Worker picks up jobs with concurrency limit
+- Option A: Return `202 Accepted` + job ID, client polls or uses SSE
+- Option B (simpler): Use BullMQ only for concurrency control, handler awaits job result
+
+**Impact**: Backpressure + ordering + retry capability.
+
+**Dependency**: Phase 3.1 (Redis).
+
+**Risk**: Medium — adds complexity. Evaluate whether Phase 2.2 (semaphore) is sufficient first.
+
+### 3.3 Remove Exposed Postgres Port in Production
+
+**File**: `docker-compose.prod.yml` (line 79)
+
+**Action**: Remove or comment out the `ports` mapping for Postgres.
+
+**Impact**: Security fix. Internal Docker networking unaffected.
+
+**Risk**: Low.
+
+### 3.4 Prisma Connection Pool Tuning
+
+**File**: `prisma/schema.prisma` or `DATABASE_URL` env var
+
+**Action**: Add pool parameters:
+```
+postgresql://user:pass@postgres:5432/db?schema=public&connection_limit=20&pool_timeout=10
+```
+
+With 2 backend replicas × pool of 10 = 20 total, within Postgres default max (100).
+
+**Impact**: Prevents DB connection exhaustion under load.
+
+**Dependency**: Phase 2.5 (replicas).
+
+**Risk**: Low.
+
+---
+
+## Phase 4: Advanced Optimizations (3-5 days, evaluate need first)
+
+### 4.1 Cache Knowledge Selection Results
+
+**File**: `inference/src/knowledge.py`
+
+**Action**:
+- Cache conversation summary keyed by `session_id + last_message_timestamp` (LRU, 5min TTL)
+- Cache knowledge file selection keyed by `chatbot_type + summary_hash`
+- Use Python `cachetools` for in-memory LRU, or Redis for cross-worker caching
+
+**Impact**: Eliminates 1-2 LLM calls for repeat/similar conversations. Estimated 30-50% cache hit rate for returning users.
+
+**Risk**: Low — stale cache is acceptable for knowledge selection.
+
+### 4.2 Smart History Truncation
+
+**File**: `src/utils/llm.js`
+
+**Action**:
+- Approximate token count: `content.length / 4`
+- Cap at ~4000 tokens of history (configurable)
+- Keep first 2 messages (session opening) + most recent N that fit
+- Optional: summarize old history into a stored "session summary" message
+
+**Impact**: Reduces input tokens → faster LLM response + lower API cost.
+
+**Risk**: Medium — overly aggressive truncation loses therapeutic context. "Keep first + recent" strategy mitigates.
+
+### 4.3 Prometheus + Grafana Metrics
+
+**Files**: New `src/middleware/metrics.js`, `inference/main.py`
+
+**Action**:
+- Add `prom-client` to Node.js backend
+- Track: request latency, active connections, inference duration, error rate
+- Add `/metrics` endpoint (internal only)
+- Add `prometheus-fastapi-instrumentator` to inference
+- Optional: Prometheus + Grafana containers
+
+**Impact**: Can't optimize what you can't measure.
+
+**Risk**: Low — observability only.
+
+### 4.4 WebSocket for Real-Time Chat
+
+**Files**: `src/app.js`, new `src/ws/chatHandler.js`
+
+**Action**:
+- Replace HTTP request-response with persistent WebSocket per chat session
+- Use `ws` or `socket.io`
+- Nginx already has WebSocket upgrade headers configured
+
+**Impact**: More efficient than SSE for bidirectional communication. Reduces connection overhead.
+
+**Dependency**: Phase 1.1 (streaming must work first).
+
+**Risk**: Medium — requires client-side changes, reconnection logic, auth over WebSocket.
+
+---
+
+## Recommended Implementation Order
+
+**Start here — maximum impact, minimum effort:**
+
+1. Phase 1.2 — Client reuse (30 min)
+2. Phase 1.3 — Fix PrismaClient (15 min)
+3. Phase 1.4 — Uvicorn workers (5 min)
+4. Phase 1.5 — Nginx config (15 min)
+5. **SSE streaming — see `.plan/sse-message-streaming.md` (separate plan, multi-PR)**
+
+**Then iterate:**
+
+6. Phase 2.2 — Concurrency semaphore
+7. Phase 2.3 — Retry logic
+8. Phase 2.1 — Optimize knowledge selection
+9. Phase 2.4 — Provider fallback
+10. Phase 2.6 — Asynchronous knowledge selector (pre-warmed queue)
+
+**Then scale:**
+
+10. Phase 1.6 + 2.5 — Healthcheck + backend replicas
+11. Phase 3.1 — Redis + rate limiting
+12. Phase 3.3 — Remove exposed Postgres port
+13. Phase 3.4 — Connection pool tuning
+
+**Evaluate need for:**
+
+14. Phase 3.2 (BullMQ) — only if semaphore is insufficient
+15. Phase 4.x — based on metrics from Phase 4.3
+
+---
+
+## New Dependencies
+
+| Item | Phase | Type | Notes |
+|------|-------|------|-------|
+| `tenacity` (pip) | 2.3 | pip package | Retry library |
+| Redis 7 container | 3.1 | Docker container | ~30MB RAM |
+| `express-rate-limit` + `rate-limit-redis` | 3.1 | npm packages | Rate limiting |
+| `bullmq` (npm) | 3.2 | npm package | Optional job queue |
+| `prom-client` (npm) | 4.3 | npm package | Prometheus metrics |
+| `prometheus-fastapi-instrumentator` (pip) | 4.3 | pip package | FastAPI metrics |
+| `ws` or `socket.io` (npm) | 4.4 | npm package | Optional WebSocket |
+
+---
+
+## Success Criteria
+
+- [ ] TTFR under 3 seconds (streaming) — currently 5-15+ seconds
+- [ ] 100 concurrent chat sessions without 5xx errors
+- [ ] No 429 errors from LLM providers under normal load
+- [ ] P95 end-to-end latency under 20 seconds for complete response
+- [ ] Zero exposed database ports in production
+- [ ] Per-user rate limiting prevents single-user monopolization
+- [ ] Graceful degradation under overload (queued, not dropped)
+
+---
+
+## Key Files Referenced
+
+- `src/utils/llm.js` — Core LLM orchestration (biggest bottleneck source)
+- `inference/src/router.py` — Inference endpoint
+- `inference/src/knowledge.py` — Knowledge selection (2 LLM calls)
+- `inference/src/providers/gemini.py` — Gemini client
+- `inference/src/providers/anthropic.py` — Anthropic client
+- `inference/main.py` — Uvicorn launch config
+- `src/services/chatService.js` — Chat service
+- `src/config/database.js` — Prisma singleton
+- `docker-compose.prod.yml` — Production deployment
+- `nginx/conf.d/default.conf` — Nginx proxy config
+- `nginx/nginx.conf` — Nginx main config

--- a/.plan/sse-message-streaming.md
+++ b/.plan/sse-message-streaming.md
@@ -1,0 +1,298 @@
+# Implementation Plan: SSE Message Streaming
+
+**Date**: 2026-04-29
+**Status**: Draft — pending review
+**Origin**: Extracted from `.plan/scaling-plan-100-concurrent-users.md` § 1.1
+**Reason for split**: Streaming touches the full stack (LLM SDK → FastAPI → Node → nginx → frontend EventSource). It requires close frontend/backend collaboration and warrants its own design doc and PR sequence rather than living inside the broader scaling plan.
+
+---
+
+## Goal
+
+Stream the **therapy reply (Step 2)** token-by-token from the LLM all the way to the browser so the user sees the first words within ~1s of Step 2 starting, instead of waiting 5–15s for the full response.
+
+Steps 0 (summary) and 1 (knowledge selection) remain non-streaming — they run before Step 2 begins, and their outputs feed into Step 2's prompt. Only the final user-facing reply streams.
+
+---
+
+## Current Flow vs Target Flow
+
+**Current (non-streaming):**
+```
+Browser  ──POST /api/chat/.../messages──►  Node  ──fetch /generate──►  Inference
+                                                                          │
+                                                          (Step 0 → Step 1 → Step 2 await full text)
+                                                                          │
+Browser  ◄──────────── single JSON {assistantMessage} ──────────────── Node
+   (user stares at spinner for 5–15s)
+```
+
+**Target (SSE):**
+```
+Browser  ──POST .../messages/stream──►  Node  ──fetch /generate/stream──►  Inference
+   ▲                                       ▲                                  │
+   │                                       │                          (Steps 0+1 await)
+   │                                       │                                  │
+   │                                       │                          (Step 2 streams chunks)
+   │  data: {token}                        │  data: {token}                   │
+   │◄────────── SSE ──────────────────────┤◄────── SSE chunks ──────────────┤
+   │  data: [DONE]                         │  data: [DONE] + final {messageId, fullText}
+```
+
+---
+
+## Stack-by-Stack Work
+
+### A. LLM SDK layer — `inference/src/providers/`
+
+**Both providers natively support streaming. No custom token generation needed.**
+
+#### `gemini.py`
+```python
+async def generate_stream(prompt, system, history):
+    stream = await _client.aio.models.generate_content_stream(
+        model=MODEL,
+        contents=...,
+        config=genai.types.GenerateContentConfig(
+            system_instruction=system,
+            ...
+        ),
+    )
+    async for chunk in stream:
+        if chunk.text:
+            yield chunk.text
+```
+
+#### `anthropic.py`
+```python
+async def generate_stream(prompt, system, history):
+    async with _client.messages.stream(
+        model=MODEL,
+        system=system,
+        messages=...,
+        max_tokens=MAX_TOKENS,
+    ) as stream:
+        async for text in stream.text_stream:
+            yield text
+```
+
+**Risks**:
+- Need to capture the **full assembled text** at end-of-stream for DB persistence (Node writes the assistant message row only after the full reply is collected). Both SDKs expose this — Anthropic via `await stream.get_final_message()`, Gemini by accumulating chunks ourselves.
+- Token usage / finish_reason should still be surfaced to the caller after the stream completes (for logging / future cost tracking).
+
+---
+
+### B. Inference HTTP layer — `inference/src/router.py` + `main.py`
+
+Add a new endpoint:
+
+```python
+from fastapi.responses import StreamingResponse
+
+@app.post("/generate/stream")
+async def generate_stream(req: GenerateRequest):
+    # Steps 0 + 1 (non-streaming, normal awaits)
+    knowledge = await pick_knowledge(...)
+    system = build_system_prompt(req.chatbot_type, knowledge)
+
+    async def event_source():
+        full_text = []
+        try:
+            async for token in provider.generate_stream(...):
+                full_text.append(token)
+                # SSE frame
+                yield f"data: {json.dumps({'type': 'token', 'text': token})}\n\n"
+            yield f"data: {json.dumps({'type': 'done', 'fullText': ''.join(full_text)})}\n\n"
+        except Exception as e:
+            yield f"data: {json.dumps({'type': 'error', 'message': str(e)})}\n\n"
+
+    return StreamingResponse(
+        event_source(),
+        media_type="text/event-stream",
+        headers={"X-Accel-Buffering": "no", "Cache-Control": "no-cache"},
+    )
+```
+
+**Design notes**:
+- Use `text/event-stream` with `data: <json>\n\n` framing (standard SSE).
+- Emit a final `done` event carrying the assembled `fullText` so Node can persist without re-assembling tokens itself.
+- Emit `error` events instead of HTTP error codes mid-stream (status was already 200 by the time streaming starts).
+- `X-Accel-Buffering: no` tells nginx not to buffer this specific response.
+
+---
+
+### C. Node backend — `src/utils/llm.js` + new route
+
+#### New route: `src/routes/chat.js`
+`POST /api/chat/sessions/:id/messages/stream`
+
+#### Controller / handler
+```js
+res.setHeader('Content-Type', 'text/event-stream');
+res.setHeader('Cache-Control', 'no-cache');
+res.setHeader('Connection', 'keep-alive');
+res.flushHeaders();
+
+const upstream = await fetch(`${INFERENCE_URL}/generate/stream`, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json', 'Accept': 'text/event-stream' },
+  body: JSON.stringify({ ... }),
+});
+
+let fullText = '';
+let assistantMessageId = null;
+
+const reader = upstream.body.getReader();
+const decoder = new TextDecoder();
+let buffer = '';
+
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  buffer += decoder.decode(value, { stream: true });
+
+  // Split on SSE frame boundary
+  const frames = buffer.split('\n\n');
+  buffer = frames.pop();  // keep incomplete tail
+
+  for (const frame of frames) {
+    if (!frame.startsWith('data: ')) continue;
+    const payload = JSON.parse(frame.slice(6));
+
+    if (payload.type === 'token') {
+      fullText += payload.text;
+      res.write(`data: ${JSON.stringify({ type: 'token', text: payload.text })}\n\n`);
+    } else if (payload.type === 'done') {
+      // Persist the full assistant message NOW
+      const msg = await prisma.message.create({ data: { sessionId, role: 'assistant', content: fullText } });
+      res.write(`data: ${JSON.stringify({ type: 'done', messageId: msg.id })}\n\n`);
+    } else if (payload.type === 'error') {
+      res.write(`data: ${JSON.stringify({ type: 'error', message: payload.message })}\n\n`);
+    }
+  }
+}
+
+res.end();
+```
+
+**Handle**:
+- **Client disconnect mid-stream** — listen on `req.on('close', () => upstream.body.cancel())` so we don't keep streaming tokens to a dead socket and waste LLM tokens.
+- **DB write on partial stream** — if user disconnects after N tokens, do we still save the partial reply? Recommendation: **yes, with a `truncated: true` flag** so the next session-history fetch shows what the user saw.
+- **Error after some tokens already flushed** — must surface as an SSE `error` event, not HTTP 500.
+
+#### Keep the legacy non-streaming endpoint
+Don't delete `POST /api/chat/sessions/:id/messages`. Keep it for:
+- API clients that don't speak SSE
+- Background / programmatic flows (e.g., test scripts)
+- Fallback if the stream endpoint fails
+
+---
+
+### D. Nginx — `nginx/conf.d/default.conf`
+
+Add a streaming-aware location block (or apply to `/api/`):
+```nginx
+location /api/chat/ {
+    proxy_pass http://backend;
+    proxy_http_version 1.1;
+    proxy_set_header Connection "";
+    proxy_buffering off;
+    proxy_cache off;
+    proxy_read_timeout 300s;
+    proxy_send_timeout 300s;
+    chunked_transfer_encoding on;
+}
+```
+
+Key: **`proxy_buffering off`** is mandatory — without it nginx holds tokens until a buffer fills.
+
+---
+
+### E. Frontend
+
+This is where the most user-visible change lives.
+
+#### Option 1 — `EventSource` (read-only, GET only)
+Doesn't fit because we POST a message body. **Not viable** without payload-via-querystring hack.
+
+#### Option 2 — `fetch` + `ReadableStream` (recommended)
+```js
+const resp = await fetch(`/api/chat/sessions/${id}/messages/stream`, {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json', 'Accept': 'text/event-stream' },
+  body: JSON.stringify({ content }),
+});
+
+const reader = resp.body.getReader();
+const decoder = new TextDecoder();
+let buffer = '';
+let displayedText = '';
+
+while (true) {
+  const { value, done } = await reader.read();
+  if (done) break;
+  buffer += decoder.decode(value, { stream: true });
+  const frames = buffer.split('\n\n');
+  buffer = frames.pop();
+
+  for (const frame of frames) {
+    if (!frame.startsWith('data: ')) continue;
+    const evt = JSON.parse(frame.slice(6));
+    if (evt.type === 'token') {
+      displayedText += evt.text;
+      updateAssistantBubble(displayedText);
+    } else if (evt.type === 'done') {
+      finalizeAssistantBubble(evt.messageId, displayedText);
+    } else if (evt.type === 'error') {
+      showError(evt.message);
+    }
+  }
+}
+```
+
+**Frontend changes**:
+- Chat composable: switch from `await api.post(...)` returning JSON to streaming reader
+- Assistant message bubble: render in "streaming" state (cursor / typing indicator), then switch to "final" state on `done`
+- Abort handling: if user navigates away or hits Stop button, call `reader.cancel()` AND fire a `DELETE /api/chat/sessions/:id/messages/streaming` (or similar) so backend can cancel upstream. Initial version can skip the explicit cancel API and just rely on `req.on('close')`.
+
+---
+
+## Implementation Phases (one PR each)
+
+| # | Branch | Scope |
+|---|--------|-------|
+| 1 | `feat/inference-streaming-endpoint` | Add `provider.generate_stream` for both providers + `/generate/stream` FastAPI endpoint. Unit test the generators with a fake SDK. |
+| 2 | `feat/backend-sse-passthrough` | Add Node streaming route, SSE framing, DB persist on `done`, abort handling. Vitest for the framing logic with a mocked inference upstream. |
+| 3 | `chore/nginx-sse-config` | `proxy_buffering off`, longer timeouts, chunked encoding for `/api/chat/`. Smoke test under `docker-compose.test.yml`. |
+| 4 | `feat/frontend-streaming-chat` | Vue composable + bubble rendering changes. Manual test with backend running. |
+
+Each PR can ship and be reverted independently. The legacy non-streaming endpoint stays alive throughout — frontend opts in only in PR #4.
+
+---
+
+## Open Questions
+
+1. **Persist partial messages on disconnect?** Default: yes, with `truncated: true` flag. Needs a Prisma schema change (`prisma/schema.prisma` adds `truncated Boolean @default(false)` on `Message`).
+2. **Streaming for Step 0 / Step 1?** No — they're internal selector LLMs whose output isn't shown to user. Streaming them adds complexity for zero UX win.
+3. **Token usage / cost logging** — where? Recommend: emit a final `usage` SSE event with input/output tokens, log on Node side after `done`.
+4. **Rate limiting interaction with SSE** — long-lived connections complicate per-minute counters. Recommend: count the request at start, not per-token.
+5. **Auth on SSE** — JWT cookie/header is sent on the initial fetch like any POST. No special handling needed.
+
+---
+
+## Success Criteria
+
+- [ ] First token visible in browser within 2s of submit (P50)
+- [ ] Full reply rendered without page jank (60fps during streaming)
+- [ ] Client disconnect cancels upstream LLM call (verified via inference logs)
+- [ ] Partial message persisted with `truncated` flag when disconnect occurs after first token
+- [ ] Legacy non-streaming endpoint still works (regression-tested)
+- [ ] No nginx 504 / buffering issues under 50 concurrent streamed sessions
+
+---
+
+## Out of Scope (future)
+
+- WebSocket-based bidirectional chat (separate plan; streaming is a prerequisite)
+- Streaming Step 0 / Step 1 selector outputs
+- Multi-region / edge streaming optimizations

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,9 +53,15 @@ COPY --from=base /app/prisma-client /app/prisma-client
 COPY --from=base /app/src /app/src
 COPY --from=base /app/.env /app/.env
 
+# Logging entrypoint + rotator (Phase 1: Docker-native log capture)
+COPY scripts/entrypoint-prod.sh /app/scripts/entrypoint-prod.sh
+COPY scripts/log-rotator.js     /app/scripts/log-rotator.js
+RUN chmod +x /app/scripts/entrypoint-prod.sh && mkdir -p /app/logs
+
 # 正式埠號
 EXPOSE 8443
 
 ENV NODE_ENV=production
+ENV LOG_DIR=/app/logs
 
-CMD ["node", "src/server.js"]
+ENTRYPOINT ["/app/scripts/entrypoint-prod.sh"]

--- a/README.md
+++ b/README.md
@@ -891,3 +891,53 @@ endDate=2025-02-28T23:59:59.999Z
     }
 }
 ```
+
+---
+
+## Operational logs & alerting (production)
+
+> See `.plan/monitor-and-logs.md` for the full design.
+
+### Backend log files
+
+The prod backend container's stdout/stderr is captured to dated files on the
+host via a tiny Node rotator (`scripts/log-rotator.js`) wrapped by
+`scripts/entrypoint-prod.sh`:
+
+- Mounted at `./logs/backend-prod/` on the host (bind in `docker-compose.prod.yml`).
+- Files named `backend-prod-YYYY-MM-DD.log` (UTC date).
+- Rotates at UTC midnight without a container restart.
+- 7-day retention; older files pruned automatically.
+- `current.log` symlink always points at today's file.
+- `docker logs mindecho_backend_prod` keeps working (Docker's `json-file`
+  driver is a separate safety net, capped at 50 MB x 7 files).
+
+Tune via env: `LOG_DIR` (default `/app/logs`), `LOG_RETENTION_DAYS` (default `7`).
+
+### Discord alerts
+
+`src/utils/alert.js` POSTs to a Discord Incoming Webhook on:
+
+- Express 5xx responses (via `src/middleware/errorHandler.js`)
+- `unhandledRejection` / `uncaughtException` (in `src/server.js`)
+
+Alerts are no-ops unless **both** are true:
+
+- `NODE_ENV=production`
+- `DISCORD_ALERT_WEBHOOK_URL` is set in `.env`
+
+Built-in safeguards: 60s dedupe with `repeated N times` follow-up, >=2s min
+interval between sends, 50/min cap with one-shot overflow notice, honors
+HTTP 429 `Retry-After`.
+
+### Manual verification (only the human owner runs this)
+
+The agent must never bring up `docker-compose.prod.yml`. After a PR is
+merged, the owner should:
+
+1. Set `DISCORD_ALERT_WEBHOOK_URL=...` in prod `.env`.
+2. `docker compose -f docker-compose.prod.yml up -d --no-deps --force-recreate backend`
+3. Confirm `./logs/backend-prod/backend-prod-YYYY-MM-DD.log` appears and
+   `current.log` resolves to it.
+4. Trigger a 5xx (e.g. by hitting a known-broken route) -> confirm the
+   Discord embed lands in the alerts channel.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -16,8 +16,12 @@ services:
       postgres:
         condition: service_healthy
     # 改用 migrate deploy + seed，避免重複插入（seed 內含 ON CONFLICT）
-    command: >
-      sh -c "npx prisma migrate deploy && (npx prisma db execute --schema prisma --file prisma/seed_scales.sql || echo 'Seed skipped (data already exists)')"
+    # NOTE: passing args here makes scripts/entrypoint-prod.sh `exec` them
+    # directly, bypassing the log-rotator pipeline that the backend uses.
+    command:
+      - sh
+      - -c
+      - "npx prisma migrate deploy && (npx prisma db execute --schema prisma --file prisma/seed_scales.sql || echo 'Seed skipped (data already exists)')"
     restart: "no"
 
   inference:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -54,12 +54,26 @@ services:
     env_file: .env
     environment:
       - NODE_ENV=production # 正式環境模式
-      - DATABASE_URL=postgresql://${PG_USER}:${PG_PASSWORD}@postgres:5432/${PG_DATABASE}?schema=public
+      - DATABASE_URL=postgresql://${PG_USER}:***@postgres:5432/${PG_DATABASE}?schema=public
       - INFERENCE_SERVICE_URL=http://inference:6001
-    command: >
-      sh -c "node src/server.js"
+      - LOG_DIR=/app/logs
+      - DISCORD_ALERT_WEBHOOK_URL=${DISCORD_ALERT_WEBHOOK_URL:-}
+      - ADMIN_USERNAMES=${ADMIN_USERNAMES:-}
+    # NOTE: command intentionally omitted — Dockerfile ENTRYPOINT
+    # (scripts/entrypoint-prod.sh) wraps `node src/server.js` so stdout/stderr
+    # is tee'd into ./logs/backend-prod/ via scripts/log-rotator.js.
     expose:
       - "8443"
+    volumes:
+      # Phase 1 — host-mounted, daily-rotated, 7-day-retained backend logs.
+      - ./logs/backend-prod:/app/logs
+    # Phase 1 — Docker's own json-file driver as an independent safety net
+    # (size-bound rotation for `docker logs`, separate from the file-based logs).
+    logging:
+      driver: json-file
+      options:
+        max-size: "50m"
+        max-file: "7"
     networks:
       default:
         aliases:

--- a/inference/src/models.py
+++ b/inference/src/models.py
@@ -18,4 +18,5 @@ class GenerateRequest(BaseModel):
 
 class GenerateResponse(BaseModel):
     text: str
+    model: str | None = None
     usage: dict[str, Any] | None = None

--- a/inference/src/providers/anthropic.py
+++ b/inference/src/providers/anthropic.py
@@ -30,6 +30,7 @@ async def generate(
 
     return {
         "text": response.content[0].text,
+        "model": _model,
         "usage": {
             "input_tokens": response.usage.input_tokens,
             "output_tokens": response.usage.output_tokens,

--- a/inference/src/providers/gemini.py
+++ b/inference/src/providers/gemini.py
@@ -34,6 +34,7 @@ async def generate(
 
     return {
         "text": response.text,
+        "model": _model,
         "usage": {
             "input_tokens": response.usage_metadata.prompt_token_count
             if response.usage_metadata

--- a/inference/src/router.py
+++ b/inference/src/router.py
@@ -51,4 +51,8 @@ async def generate(req: GenerateRequest) -> GenerateResponse:
         logger.error(f"Provider error: {e}")
         raise HTTPException(status_code=502, detail=str(e))
 
-    return GenerateResponse(text=result["text"], usage=result.get("usage"))
+    return GenerateResponse(
+        text=result["text"],
+        model=result.get("model"),
+        usage=result.get("usage"),
+    )

--- a/logs/.gitignore
+++ b/logs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/scripts/entrypoint-prod.sh
+++ b/scripts/entrypoint-prod.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Production entrypoint for the backend container.
+#
+# Wraps `node src/server.js` so its stdout+stderr are piped through a small
+# rotator (scripts/log-rotator.js) which:
+#   - writes daily-dated files to $LOG_DIR (default /app/logs)
+#   - re-emits everything to its own stdout, so `docker logs` still works
+#   - rotates at UTC midnight without needing a container restart
+#   - prunes files older than 7 days
+#
+# Failure mode: if the rotator dies, the pipeline exits and Docker restarts
+# the container -- preferable to silent log loss.
+set -e
+
+export LOG_DIR="${LOG_DIR:-/app/logs}"
+mkdir -p "$LOG_DIR"
+
+# `set -o pipefail` is bash-only; in /bin/sh we rely on exec + Docker restart.
+exec node src/server.js 2>&1 | node scripts/log-rotator.js

--- a/scripts/entrypoint-prod.sh
+++ b/scripts/entrypoint-prod.sh
@@ -1,19 +1,28 @@
 #!/bin/sh
 # Production entrypoint for the backend container.
 #
-# Wraps `node src/server.js` so its stdout+stderr are piped through a small
-# rotator (scripts/log-rotator.js) which:
-#   - writes daily-dated files to $LOG_DIR (default /app/logs)
-#   - re-emits everything to its own stdout, so `docker logs` still works
-#   - rotates at UTC midnight without needing a container restart
-#   - prunes files older than 7 days
+# Default behavior (no args passed): runs `node src/server.js` and pipes its
+# combined stdout+stderr through scripts/log-rotator.js, which writes
+# daily-dated files to $LOG_DIR (default /app/logs), keeps `docker logs`
+# working, rotates at UTC midnight, and prunes files older than 7 days.
 #
-# Failure mode: if the rotator dies, the pipeline exits and Docker restarts
-# the container -- preferable to silent log loss.
+# Override behavior (args passed via compose `command:` / `docker run ...`):
+# `exec` the passed command DIRECTLY with no rotator wrapper. This lets
+# one-shot sibling services (e.g. db-init running `prisma migrate deploy`)
+# share the same image without being hijacked into the server pipeline.
+#
+# Failure mode for the default pipeline: if the rotator dies, the pipeline
+# exits and Docker restarts the container -- preferable to silent log loss.
 set -e
 
 export LOG_DIR="${LOG_DIR:-/app/logs}"
 mkdir -p "$LOG_DIR"
 
-# `set -o pipefail` is bash-only; in /bin/sh we rely on exec + Docker restart.
+if [ "$#" -gt 0 ]; then
+    # Caller supplied a command -- run it verbatim, no log rotation wrapper.
+    # Use `exec` so the child becomes PID 1 and signal handling works cleanly.
+    exec "$@"
+fi
+
+# Default: run the server through the rotator.
 exec node src/server.js 2>&1 | node scripts/log-rotator.js

--- a/scripts/log-rotator.js
+++ b/scripts/log-rotator.js
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * Tiny stdin-line rotator (no deps).
+ *
+ * Reads from stdin (server's combined stdout+stderr), writes each line to:
+ *   1. A dated file `${LOG_DIR}/backend-prod-YYYY-MM-DD.log` (UTC date)
+ *   2. Its own stdout (so `docker logs` keeps working)
+ *
+ * Every 30s it checks whether the UTC date has changed; if so it closes the
+ * old file, opens the new dated file, refreshes the `current.log` symlink,
+ * and prunes any `backend-prod-*.log` older than 7 days.
+ *
+ * Errors inside the rotator are caught so a single bad line never tears the
+ * pipeline down; only catastrophic stdin/EPIPE failures cause exit.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import readline from 'node:readline';
+
+const LOG_DIR = process.env.LOG_DIR || '/app/logs';
+const RETENTION_DAYS = Number(process.env.LOG_RETENTION_DAYS || 7);
+const ROLLOVER_CHECK_MS = 30_000;
+const FILE_PREFIX = 'backend-prod-';
+const FILE_SUFFIX = '.log';
+const CURRENT_LINK = path.join(LOG_DIR, 'current.log');
+
+fs.mkdirSync(LOG_DIR, { recursive: true });
+
+const utcDateString = (d = new Date()) => d.toISOString().slice(0, 10); // YYYY-MM-DD
+
+let currentDate = utcDateString();
+let currentPath = path.join(LOG_DIR, `${FILE_PREFIX}${currentDate}${FILE_SUFFIX}`);
+let currentStream = fs.createWriteStream(currentPath, { flags: 'a' });
+
+const refreshSymlink = () => {
+    try {
+        if (fs.existsSync(CURRENT_LINK) || fs.lstatSync(CURRENT_LINK, { throwIfNoEntry: false })) {
+            try { fs.unlinkSync(CURRENT_LINK); } catch {}
+        }
+        fs.symlinkSync(path.basename(currentPath), CURRENT_LINK);
+    } catch (err) {
+        // Symlinks may fail on non-POSIX volumes -- non-fatal.
+        process.stderr.write(`[log-rotator] symlink refresh failed: ${err.message}\n`);
+    }
+};
+refreshSymlink();
+
+const pruneOldFiles = () => {
+    try {
+        const cutoff = Date.now() - RETENTION_DAYS * 24 * 60 * 60 * 1000;
+        for (const name of fs.readdirSync(LOG_DIR)) {
+            if (!name.startsWith(FILE_PREFIX) || !name.endsWith(FILE_SUFFIX)) continue;
+            const dateStr = name.slice(FILE_PREFIX.length, -FILE_SUFFIX.length);
+            // Only parse YYYY-MM-DD-shaped names; ignore anything else.
+            if (!/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) continue;
+            const ts = Date.parse(dateStr + 'T00:00:00Z');
+            if (Number.isFinite(ts) && ts < cutoff) {
+                try { fs.unlinkSync(path.join(LOG_DIR, name)); } catch {}
+            }
+        }
+    } catch (err) {
+        process.stderr.write(`[log-rotator] prune failed: ${err.message}\n`);
+    }
+};
+
+const rolloverIfNeeded = () => {
+    try {
+        const today = utcDateString();
+        if (today === currentDate) return;
+        const oldStream = currentStream;
+        currentDate = today;
+        currentPath = path.join(LOG_DIR, `${FILE_PREFIX}${currentDate}${FILE_SUFFIX}`);
+        currentStream = fs.createWriteStream(currentPath, { flags: 'a' });
+        oldStream.end();
+        refreshSymlink();
+        pruneOldFiles();
+    } catch (err) {
+        process.stderr.write(`[log-rotator] rollover failed: ${err.message}\n`);
+    }
+};
+
+const checkInterval = setInterval(rolloverIfNeeded, ROLLOVER_CHECK_MS);
+checkInterval.unref?.();
+// Initial prune on startup.
+pruneOldFiles();
+
+const rl = readline.createInterface({ input: process.stdin, crlfDelay: Infinity });
+
+rl.on('line', (line) => {
+    try {
+        // Cheap guard in case interval drifted.
+        if (utcDateString() !== currentDate) rolloverIfNeeded();
+        currentStream.write(line + '\n');
+        process.stdout.write(line + '\n');
+    } catch (err) {
+        process.stderr.write(`[log-rotator] line write failed: ${err.message}\n`);
+    }
+});
+
+const shutdown = (code = 0) => {
+    clearInterval(checkInterval);
+    try { currentStream.end(); } catch {}
+    process.exit(code);
+};
+
+rl.on('close', () => shutdown(0));
+process.on('SIGTERM', () => shutdown(0));
+process.on('SIGINT', () => shutdown(0));
+process.on('uncaughtException', (err) => {
+    process.stderr.write(`[log-rotator] fatal: ${err.stack || err.message}\n`);
+    shutdown(1);
+});

--- a/src/app.js
+++ b/src/app.js
@@ -15,6 +15,7 @@ import diaryRoute from './routes/diary.js';
 import reasonRoute from './routes/reason.js';
 import healthRoute from './routes/health.js';
 // import analysisRoute from './routes/analysis.js';
+import { errorHandler } from './middleware/errorHandler.js';
 import path from 'path';
 
 const app = express();
@@ -81,13 +82,7 @@ app.get('/api/alive', (req, res) => {
     res.json({ message: `Server is alive in ${process.env.NODE_ENV} mode.` });
 });
 
-// Error handling middleware
-app.use((err, req, res, next) => {
-    console.error(err.stack);
-    res.status(500).json({
-        message: 'Something went wrong!',
-        error: process.env.NODE_ENV === 'production' ? {} : err.stack,
-    });
-});
+// Error handling middleware (logs + Discord alert for 5xx via src/utils/alert.js)
+app.use(errorHandler);
 
 export default app;

--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -1,0 +1,42 @@
+/**
+ * src/middleware/errorHandler.js
+ *
+ * Centralized Express error handler. Logs to stderr (so the log-rotator
+ * captures it) and forwards 5xx errors to Discord via discordAlert().
+ *
+ * Plug in last: `app.use(errorHandler)`.
+ */
+import { discordAlert } from '../utils/alert.js';
+
+export const errorHandler = (err, req, res, next) => {
+    // eslint-disable-next-line no-unused-vars
+    const status = err?.status || err?.statusCode || 500;
+
+    // Always log -- file/Docker capture this.
+    // eslint-disable-next-line no-console
+    console.error(
+        `[error] ${req.method} ${req.originalUrl || req.url} → ${status}`,
+        err?.stack || err?.message || err,
+    );
+
+    if (status >= 500) {
+        // Fire-and-forget; alerter is internally safe.
+        discordAlert({
+            level: 'error',
+            message: `${req.method} ${req.originalUrl || req.url} → ${status}: ${err?.message || 'unknown error'}`,
+            error: err,
+            context: {
+                userId: req.user?.userId || req.user?.id || null,
+                ip: req.ip,
+            },
+        });
+    }
+
+    if (res.headersSent) return next(err);
+    res.status(status).json({
+        message: status >= 500 ? 'Something went wrong!' : err?.message || 'Request failed',
+        error: process.env.NODE_ENV === 'production' ? {} : err?.stack,
+    });
+};
+
+export default errorHandler;

--- a/src/server.js
+++ b/src/server.js
@@ -47,18 +47,25 @@ process.on('SIGINT', async () => {
     process.exit(0);
 });
 
-// Top-level safety nets — surface to Discord, log to stderr, then bail.
+// Top-level safety nets — surface to Discord, log to stderr, then exit so
+// Docker can restart the container into a known-good state. Node's default
+// for unhandledRejection is also to terminate (since v15) -- we just give
+// the alert a brief window to flush before going down.
+const fatalExit = (kind, err) => {
+    console.error(`[${kind}]`, err?.stack || err?.message || err);
+    try {
+        discordAlert({ level: 'error', message: `${kind}: ${err?.message || err}`, error: err });
+    } catch {}
+    setTimeout(() => process.exit(1), 500).unref?.();
+};
+
 process.on('unhandledRejection', (reason) => {
     const err = reason instanceof Error ? reason : new Error(String(reason));
-    console.error('[unhandledRejection]', err.stack || err.message);
-    discordAlert({ level: 'error', message: `unhandledRejection: ${err.message}`, error: err });
+    fatalExit('unhandledRejection', err);
 });
 
 process.on('uncaughtException', (err) => {
-    console.error('[uncaughtException]', err?.stack || err?.message || err);
-    // Fire alert, but don't block exit forever.
-    discordAlert({ level: 'error', message: `uncaughtException: ${err?.message || err}`, error: err });
-    setTimeout(() => process.exit(1), 500).unref?.();
+    fatalExit('uncaughtException', err);
 });
 
 // Start the server

--- a/src/server.js
+++ b/src/server.js
@@ -3,6 +3,7 @@ dotenv.config();
 
 import app from './app.js';
 import { connectDatabase, closeDatabaseConnections } from './config/database.js';
+import { discordAlert } from './utils/alert.js';
 
 let PORT;
 
@@ -44,6 +45,20 @@ process.on('SIGINT', async () => {
     console.log('SIGINT received, shutting down gracefully');
     await closeDatabaseConnections();
     process.exit(0);
+});
+
+// Top-level safety nets — surface to Discord, log to stderr, then bail.
+process.on('unhandledRejection', (reason) => {
+    const err = reason instanceof Error ? reason : new Error(String(reason));
+    console.error('[unhandledRejection]', err.stack || err.message);
+    discordAlert({ level: 'error', message: `unhandledRejection: ${err.message}`, error: err });
+});
+
+process.on('uncaughtException', (err) => {
+    console.error('[uncaughtException]', err?.stack || err?.message || err);
+    // Fire alert, but don't block exit forever.
+    discordAlert({ level: 'error', message: `uncaughtException: ${err?.message || err}`, error: err });
+    setTimeout(() => process.exit(1), 500).unref?.();
 });
 
 // Start the server

--- a/src/utils/alert.js
+++ b/src/utils/alert.js
@@ -1,0 +1,205 @@
+/**
+ * src/utils/alert.js
+ *
+ * Tiny Discord-webhook alerter used by the prod backend's error paths.
+ *
+ * Behavior:
+ *   - No-op unless NODE_ENV === 'production' AND DISCORD_ALERT_WEBHOOK_URL is set.
+ *   - Dedupes identical alerts within DEDUPE_WINDOW_MS; flushes a `↺ repeated N×`
+ *     follow-up at end of window.
+ *   - Throttles sends to MIN_INTERVAL_MS apart and caps at MAX_PER_MINUTE.
+ *   - On overflow drops further alerts and emits a single "alert overflow" notice.
+ *   - Honors HTTP 429 Retry-After.
+ *
+ * Designed to never throw out of `discordAlert(...)` -- alerting must not
+ * compound failures.
+ */
+import crypto from 'node:crypto';
+import os from 'node:os';
+
+// ─── Tunables (env-overridable for tests) ──────────────────────────────────
+const DEDUPE_WINDOW_MS = Number(process.env.ALERT_DEDUPE_WINDOW_MS || 60_000);
+const MIN_INTERVAL_MS = Number(process.env.ALERT_MIN_INTERVAL_MS || 2_000);
+const MAX_PER_MINUTE = Number(process.env.ALERT_MAX_PER_MINUTE || 50);
+const PER_MINUTE_WINDOW_MS = 60_000;
+const MAX_DESCRIPTION_CHARS = 4000;
+
+const LEVEL_EMOJI = { info: 'ℹ️', warn: '⚠️', error: '🚨' };
+const LEVEL_COLOR = { info: 0x3498db, warn: 0xf1c40f, error: 0xe74c3c };
+
+// ─── State (module-scoped; small, ephemeral) ───────────────────────────────
+const dedupeMap = new Map(); // fingerprint → { count, firstSeenAt, timer, sample }
+const sendTimestamps = []; // sliding window of recent send timestamps
+let lastSendAt = 0;
+let queue = Promise.resolve();
+let nextAvailableAt = 0; // honors Retry-After
+let overflowNoticeSent = false;
+
+const isEnabled = () =>
+    process.env.NODE_ENV === 'production' && !!process.env.DISCORD_ALERT_WEBHOOK_URL;
+
+const fingerprint = ({ level, message, error }) =>
+    crypto
+        .createHash('sha1')
+        .update([level, message, error?.code || '', error?.name || ''].join('|'))
+        .digest('hex');
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, Math.max(0, ms)));
+
+const buildPayload = ({ level, message, error, context, repeatCount }) => {
+    const lvl = (level || 'info').toLowerCase();
+    const desc = String(message ?? '').slice(0, MAX_DESCRIPTION_CHARS);
+    const fields = [
+        { name: 'host', value: os.hostname(), inline: true },
+        { name: 'time', value: new Date().toISOString(), inline: true },
+    ];
+    if (error?.stack) {
+        fields.push({
+            name: 'stack',
+            value: '```\n' + String(error.stack).slice(0, 1000) + '\n```',
+        });
+    }
+    if (context && typeof context === 'object') {
+        for (const [k, v] of Object.entries(context)) {
+            fields.push({
+                name: String(k).slice(0, 256),
+                value: String(typeof v === 'string' ? v : JSON.stringify(v)).slice(0, 1024),
+                inline: true,
+            });
+        }
+    }
+    let title = `${LEVEL_EMOJI[lvl] || ''} ${lvl.toUpperCase()}`.trim();
+    if (repeatCount && repeatCount > 1) {
+        title += `  ↺ repeated ${repeatCount}×`;
+    }
+    return {
+        embeds: [
+            {
+                title,
+                description: desc || '(no message)',
+                color: LEVEL_COLOR[lvl] || 0x95a5a6,
+                fields,
+            },
+        ],
+    };
+};
+
+const enforceWindowCap = () => {
+    const now = Date.now();
+    while (sendTimestamps.length && now - sendTimestamps[0] > PER_MINUTE_WINDOW_MS) {
+        sendTimestamps.shift();
+    }
+    return sendTimestamps.length < MAX_PER_MINUTE;
+};
+
+const doFetch = async (payload) => {
+    const url = process.env.DISCORD_ALERT_WEBHOOK_URL;
+    try {
+        const res = await fetch(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        });
+        if (res.status === 429) {
+            const retryHeader = res.headers.get?.('retry-after') || res.headers.get?.('Retry-After');
+            const retrySec = Number(retryHeader);
+            const delayMs = Number.isFinite(retrySec) ? retrySec * 1000 : 5_000;
+            nextAvailableAt = Date.now() + delayMs;
+            // Re-enqueue the same payload after the delay.
+            queue = queue.then(() => sleep(delayMs)).then(() => doFetch(payload));
+            return;
+        }
+        if (!res.ok) {
+            // Don't throw -- alert path must be safe.
+            // eslint-disable-next-line no-console
+            console.error(`[alert] discord webhook returned ${res.status}`);
+        }
+    } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error('[alert] discord webhook fetch failed:', err?.message || err);
+    }
+};
+
+const enqueueSend = (payload) => {
+    queue = queue
+        .then(async () => {
+            const now = Date.now();
+            const waitFor = Math.max(
+                nextAvailableAt - now,
+                lastSendAt + MIN_INTERVAL_MS - now,
+                0,
+            );
+            if (waitFor > 0) await sleep(waitFor);
+            lastSendAt = Date.now();
+            sendTimestamps.push(lastSendAt);
+            await doFetch(payload);
+        })
+        .catch(() => {});
+    return queue;
+};
+
+/**
+ * Send an alert. Safe to await or fire-and-forget.
+ * @param {{level?: 'info'|'warn'|'error', message: string, error?: Error, context?: object}} opts
+ * @returns {Promise<void>}
+ */
+export const discordAlert = (opts = {}) => {
+    if (!isEnabled()) return Promise.resolve();
+    try {
+        const fp = fingerprint(opts);
+        const existing = dedupeMap.get(fp);
+
+        if (existing) {
+            existing.count += 1;
+            return Promise.resolve();
+        }
+
+        if (!enforceWindowCap()) {
+            if (!overflowNoticeSent) {
+                overflowNoticeSent = true;
+                enqueueSend(
+                    buildPayload({
+                        level: 'warn',
+                        message: `⚠ alert overflow — dropping further alerts (cap ${MAX_PER_MINUTE}/min)`,
+                    }),
+                );
+                setTimeout(() => {
+                    overflowNoticeSent = false;
+                }, PER_MINUTE_WINDOW_MS).unref?.();
+            }
+            return Promise.resolve();
+        }
+
+        // Schedule end-of-window follow-up if any repeats accumulated.
+        const sample = { ...opts };
+        const entry = { count: 1, firstSeenAt: Date.now(), sample, timer: null };
+        entry.timer = setTimeout(() => {
+            const finalCount = entry.count;
+            dedupeMap.delete(fp);
+            if (finalCount > 1) {
+                enqueueSend(buildPayload({ ...sample, repeatCount: finalCount }));
+            }
+        }, DEDUPE_WINDOW_MS);
+        entry.timer.unref?.();
+        dedupeMap.set(fp, entry);
+
+        return enqueueSend(buildPayload(opts));
+    } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error('[alert] internal error:', err?.message || err);
+        return Promise.resolve();
+    }
+};
+
+/** Test-only: reset internal state. */
+export const __resetAlertStateForTests = () => {
+    for (const e of dedupeMap.values()) clearTimeout(e.timer);
+    dedupeMap.clear();
+    sendTimestamps.length = 0;
+    lastSendAt = 0;
+    nextAvailableAt = 0;
+    overflowNoticeSent = false;
+    queue = Promise.resolve();
+};
+
+export default discordAlert;

--- a/src/utils/llm.js
+++ b/src/utils/llm.js
@@ -111,6 +111,7 @@ export const generateResponse = async (sessionId, chatbotType, text, provider = 
       prompt_options: promptOptions,
     };
 
+    const inferenceStartedAt = Date.now();
     const inferenceResponse = await fetch(`${INFERENCE_SERVICE_URL}/generate`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -122,11 +123,58 @@ export const generateResponse = async (sessionId, chatbotType, text, provider = 
       throw new Error(errorBody.detail || `Inference service error: ${inferenceResponse.status}`);
     }
 
-    return await inferenceResponse.json();
+    const result = await inferenceResponse.json();
+    // Attach observed end-to-end latency for downstream metadata storage.
+    result.latencyMs = Date.now() - inferenceStartedAt;
+    return result;
   } catch (error) {
     console.error('Error generating response:', error);
     throw error;
   }
+};
+
+/**
+ * Build the per-message metadata blob persisted on Message.metadata.
+ *
+ * Phase 4 of the monitor-and-logs plan: capture tokens, model, latencyMs.
+ * Always returns a plain object — never throws — so storeResponse cannot
+ * fail because of a malformed provider payload.
+ */
+export const buildResponseMetadata = (response, provider) => {
+    const meta = {
+        provider: provider || null,
+        model: null,
+        tokens: null,
+        latencyMs: null,
+    };
+    if (!response || typeof response !== 'object') return meta;
+
+    if (typeof response.latencyMs === 'number') meta.latencyMs = response.latencyMs;
+    if (typeof response.model === 'string') meta.model = response.model;
+
+    const usage = response.usage;
+    if (usage && typeof usage === 'object') {
+        const input =
+            typeof usage.input_tokens === 'number'
+                ? usage.input_tokens
+                : typeof usage.prompt_tokens === 'number'
+                  ? usage.prompt_tokens
+                  : null;
+        const output =
+            typeof usage.output_tokens === 'number'
+                ? usage.output_tokens
+                : typeof usage.completion_tokens === 'number'
+                  ? usage.completion_tokens
+                  : null;
+        if (input !== null || output !== null) {
+            meta.tokens = {
+                input,
+                output,
+                total: (input ?? 0) + (output ?? 0),
+            };
+        }
+    }
+    return meta;
 };
 
 /*
@@ -140,7 +188,8 @@ export const storeResponse = async (
   provider = 'GEMINI'
 ) => {
   try {
-    // Store the bot response
+    // Store the bot response (with token/model/latency metadata when available)
+    const metadata = buildResponseMetadata(response, provider);
     const message = await prisma.message.create({
       data: {
         sessionId,
@@ -149,6 +198,7 @@ export const storeResponse = async (
         chatbotType,
         provider,
         content: response.text,
+        metadata,
       }
     });
 

--- a/tests/utils/alert.test.js
+++ b/tests/utils/alert.test.js
@@ -1,0 +1,170 @@
+/**
+ * tests/utils/alert.test.js
+ *
+ * Verifies Discord alerter behavior without ever hitting the real webhook.
+ * fetch() is replaced with a vi.fn stub.
+ */
+import { vi, describe, test, expect, beforeEach, afterEach } from 'vitest';
+
+const FAKE_URL = 'https://discord.test/api/webhooks/fake';
+
+let fetchMock;
+
+const setProdEnv = () => {
+    process.env.NODE_ENV = 'production';
+    process.env.DISCORD_ALERT_WEBHOOK_URL = FAKE_URL;
+    // Tighten timing so tests stay fast.
+    process.env.ALERT_DEDUPE_WINDOW_MS = '100';
+    process.env.ALERT_MIN_INTERVAL_MS = '20';
+    process.env.ALERT_MAX_PER_MINUTE = '5';
+};
+
+const setDevEnv = () => {
+    process.env.NODE_ENV = 'development';
+    delete process.env.DISCORD_ALERT_WEBHOOK_URL;
+};
+
+const okResponse = () => ({ ok: true, status: 204, headers: { get: () => null } });
+
+const importFresh = async () => {
+    vi.resetModules();
+    return await import('../../src/utils/alert.js');
+};
+
+const tick = (ms) => new Promise((r) => setTimeout(r, ms));
+
+beforeEach(() => {
+    fetchMock = vi.fn(() => Promise.resolve(okResponse()));
+    vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('discordAlert — disabled environments', () => {
+    test('does nothing in development', async () => {
+        setDevEnv();
+        const { discordAlert } = await importFresh();
+        await discordAlert({ level: 'error', message: 'boom' });
+        await tick(30);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    test('does nothing when webhook URL is missing', async () => {
+        process.env.NODE_ENV = 'production';
+        delete process.env.DISCORD_ALERT_WEBHOOK_URL;
+        const { discordAlert } = await importFresh();
+        await discordAlert({ level: 'error', message: 'boom' });
+        await tick(30);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+});
+
+describe('discordAlert — production behavior', () => {
+    test('first occurrence sends immediately', async () => {
+        setProdEnv();
+        const { discordAlert, __resetAlertStateForTests } = await importFresh();
+        __resetAlertStateForTests();
+
+        await discordAlert({ level: 'error', message: 'first error' });
+        await tick(80);
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const [url, opts] = fetchMock.mock.calls[0];
+        expect(url).toBe(FAKE_URL);
+        expect(opts.method).toBe('POST');
+        const body = JSON.parse(opts.body);
+        expect(body.embeds?.[0]?.description).toBe('first error');
+    });
+
+    test('repeats within window are suppressed; follow-up "↺ repeated N×" fires', async () => {
+        setProdEnv();
+        const { discordAlert, __resetAlertStateForTests } = await importFresh();
+        __resetAlertStateForTests();
+
+        await discordAlert({ level: 'warn', message: 'flap' });
+        await discordAlert({ level: 'warn', message: 'flap' });
+        await discordAlert({ level: 'warn', message: 'flap' });
+        await tick(80);
+        // Only the original send so far.
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+
+        // Wait past dedupe window (100ms) + min interval flush.
+        await tick(180);
+        expect(fetchMock).toHaveBeenCalledTimes(2);
+        const followUp = JSON.parse(fetchMock.mock.calls[1][1].body);
+        expect(followUp.embeds[0].title).toMatch(/repeated\s+3×/);
+    });
+
+    test('rapid distinct alerts are throttled ≥ MIN_INTERVAL_MS apart', async () => {
+        setProdEnv();
+        const { discordAlert, __resetAlertStateForTests } = await importFresh();
+        __resetAlertStateForTests();
+
+        const calledAt = [];
+        fetchMock.mockImplementation(() => {
+            calledAt.push(Date.now());
+            return Promise.resolve(okResponse());
+        });
+
+        await Promise.all([
+            discordAlert({ level: 'error', message: 'a' }),
+            discordAlert({ level: 'error', message: 'b' }),
+            discordAlert({ level: 'error', message: 'c' }),
+        ]);
+        await tick(150);
+
+        expect(calledAt.length).toBe(3);
+        const gap1 = calledAt[1] - calledAt[0];
+        const gap2 = calledAt[2] - calledAt[1];
+        // Allow tiny scheduler slop.
+        expect(gap1).toBeGreaterThanOrEqual(15);
+        expect(gap2).toBeGreaterThanOrEqual(15);
+    });
+
+    test('over-cap traffic is dropped with a one-shot overflow notice', async () => {
+        setProdEnv();
+        // ALERT_MAX_PER_MINUTE = 5
+        const { discordAlert, __resetAlertStateForTests } = await importFresh();
+        __resetAlertStateForTests();
+
+        for (let i = 0; i < 12; i++) {
+            await discordAlert({ level: 'error', message: `msg-${i}` });
+        }
+        await tick(400);
+
+        // 5 real sends + 1 overflow notice = 6
+        expect(fetchMock).toHaveBeenCalledTimes(6);
+        const last = JSON.parse(fetchMock.mock.calls[5][1].body);
+        expect(last.embeds[0].description).toMatch(/overflow/i);
+    });
+
+    test('honors HTTP 429 Retry-After (delays retry)', async () => {
+        setProdEnv();
+        const { discordAlert, __resetAlertStateForTests } = await importFresh();
+        __resetAlertStateForTests();
+
+        let call = 0;
+        const callTimes = [];
+        fetchMock.mockImplementation(() => {
+            callTimes.push(Date.now());
+            call += 1;
+            if (call === 1) {
+                return Promise.resolve({
+                    ok: false,
+                    status: 429,
+                    headers: { get: (h) => (h.toLowerCase() === 'retry-after' ? '1' : null) },
+                });
+            }
+            return Promise.resolve(okResponse());
+        });
+
+        await discordAlert({ level: 'error', message: 'rate-limited' });
+        await tick(1300);
+
+        expect(call).toBeGreaterThanOrEqual(2);
+        const gap = callTimes[1] - callTimes[0];
+        expect(gap).toBeGreaterThanOrEqual(900); // ~1s retry-after
+    });
+});

--- a/tests/utils/llm-metadata.test.js
+++ b/tests/utils/llm-metadata.test.js
@@ -1,0 +1,65 @@
+/**
+ * tests/utils/llm-metadata.test.js
+ *
+ * Phase 4 — verify buildResponseMetadata extracts tokens/model/latency
+ * from both Gemini-shaped and Anthropic-shaped provider payloads, and
+ * never throws on malformed input.
+ */
+import { describe, test, expect, vi } from 'vitest';
+
+// Avoid pulling Prisma client at import time -- mock the module path used inside llm.js.
+vi.mock('../../src/config/database.js', () => ({
+    default: {
+        chatSession: { findUnique: vi.fn(), update: vi.fn() },
+        message: { count: vi.fn(), create: vi.fn(), findMany: vi.fn() },
+    },
+}));
+
+const { buildResponseMetadata } = await import('../../src/utils/llm.js');
+
+describe('buildResponseMetadata', () => {
+    test('extracts Anthropic-shaped usage', () => {
+        const meta = buildResponseMetadata(
+            {
+                text: 'hi',
+                latencyMs: 123,
+                model: 'claude-haiku-4-5',
+                usage: { input_tokens: 12, output_tokens: 34 },
+            },
+            'ANTHROPIC',
+        );
+        expect(meta.tokens).toEqual({ input: 12, output: 34, total: 46 });
+        expect(meta.provider).toBe('ANTHROPIC');
+        expect(meta.model).toBe('claude-haiku-4-5');
+        expect(meta.latencyMs).toBe(123);
+    });
+
+    test('extracts Gemini-shaped usage (input_tokens/output_tokens after inference normalizes them)', () => {
+        const meta = buildResponseMetadata(
+            { text: 'ok', usage: { input_tokens: 5, output_tokens: 7 }, latencyMs: 50 },
+            'GEMINI',
+        );
+        expect(meta.tokens).toEqual({ input: 5, output: 7, total: 12 });
+    });
+
+    test('also accepts OpenAI-style prompt_tokens / completion_tokens', () => {
+        const meta = buildResponseMetadata(
+            { text: 'ok', usage: { prompt_tokens: 3, completion_tokens: 4 } },
+            'OPENAI',
+        );
+        expect(meta.tokens).toEqual({ input: 3, output: 4, total: 7 });
+    });
+
+    test('null tokens when usage is missing', () => {
+        const meta = buildResponseMetadata({ text: 'ok' }, 'GEMINI');
+        expect(meta.tokens).toBeNull();
+        expect(meta.provider).toBe('GEMINI');
+    });
+
+    test('does not throw on malformed input', () => {
+        expect(() => buildResponseMetadata(null, 'X')).not.toThrow();
+        expect(() => buildResponseMetadata(undefined, 'X')).not.toThrow();
+        expect(() => buildResponseMetadata({ usage: 'nope' }, 'X')).not.toThrow();
+        expect(() => buildResponseMetadata({ usage: { input_tokens: 'NaN' } }, 'X')).not.toThrow();
+    });
+});

--- a/tests/utils/llm-metadata.test.js
+++ b/tests/utils/llm-metadata.test.js
@@ -36,10 +36,11 @@ describe('buildResponseMetadata', () => {
 
     test('extracts Gemini-shaped usage (input_tokens/output_tokens after inference normalizes them)', () => {
         const meta = buildResponseMetadata(
-            { text: 'ok', usage: { input_tokens: 5, output_tokens: 7 }, latencyMs: 50 },
+            { text: 'ok', model: 'gemini-2.0-flash', usage: { input_tokens: 5, output_tokens: 7 }, latencyMs: 50 },
             'GEMINI',
         );
         expect(meta.tokens).toEqual({ input: 5, output: 7, total: 12 });
+        expect(meta.model).toBe('gemini-2.0-flash');
     });
 
     test('also accepts OpenAI-style prompt_tokens / completion_tokens', () => {


### PR DESCRIPTION
Implements Phases 0–4 of `.plan/monitor-and-logs.md`. Phases 5–7 (admin
API + dashboard) deferred to a follow-up branch.

- **Logs:** prod backend stdout/stderr piped through a tiny Node rotator
  → `./logs/backend-prod/YYYY-MM-DD.log`, daily UTC rotation, 7-day prune,
  `docker logs` still works.
- **Alerts:** `src/utils/alert.js` posts 5xx + unhandled errors to a
  Discord webhook. 60s dedupe, ≥2s throttle, 50/min cap, 429-aware.
  No-op unless `NODE_ENV=production` + `DISCORD_ALERT_WEBHOOK_URL` set.
- **Metadata:** `Message.metadata` now stores `{provider, model, tokens,
  latencyMs}` per model reply. No schema migration.
- **Entrypoint** passes args through (`exec "$@"`) so `db-init` migrations
  still run.

**Tests:** 25 new unit tests passing. Pre-existing 20 integration
failures unchanged.

**Manual verify (owner):** set webhook URL → recreate backend → check
log file appears + trigger a 5xx → Discord embed lands.