### PR TITLE
Inference Reliability Baseline

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -33,6 +33,9 @@ services:
     environment:
       - INFERENCE_PORT=6001
       - INFERENCE_WORKERS=4
+      # Per-worker cap on concurrent outbound LLM calls (Phase 2.2 backpressure).
+      # Effective ceiling = MAX_CONCURRENT_LLM_CALLS * INFERENCE_WORKERS.
+      - MAX_CONCURRENT_LLM_CALLS=20
     expose:
       - "6001"
     healthcheck:

--- a/inference/pyproject.toml
+++ b/inference/pyproject.toml
@@ -12,4 +12,5 @@ dependencies = [
     "pydantic>=2.0.0",
     "python-dotenv>=1.0.0",
     "python-frontmatter>=1.1.0",
+    "tenacity>=8.2.0",
 ]

--- a/inference/src/knowledge.py
+++ b/inference/src/knowledge.py
@@ -13,6 +13,8 @@ import re
 import logging
 import frontmatter
 
+from .retry_utils import call_with_retry
+
 logger = logging.getLogger(__name__)
 
 DOCS_SUMS_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "docs", "sums")
@@ -156,14 +158,16 @@ async def _call_gemini_selection(system: str, user: str, max_tokens: int) -> str
 
     api_key = os.environ.get("GEMINI_API_KEY")
     client = genai.Client(api_key=api_key)
-    response = await client.aio.models.generate_content(
-        model=SELECTION_MODEL_GEMINI,
-        contents=user,
-        config=genai.types.GenerateContentConfig(
-            system_instruction=system,
-            temperature=0.0,
-            max_output_tokens=max_tokens,
-        ),
+    response = await call_with_retry(
+        lambda: client.aio.models.generate_content(
+            model=SELECTION_MODEL_GEMINI,
+            contents=user,
+            config=genai.types.GenerateContentConfig(
+                system_instruction=system,
+                temperature=0.0,
+                max_output_tokens=max_tokens,
+            ),
+        )
     )
     return response.text or ""
 
@@ -173,11 +177,13 @@ async def _call_anthropic_selection(system: str, user: str, max_tokens: int) -> 
 
     api_key = os.environ.get("ANTHROPIC_API_KEY")
     client = anthropic.AsyncAnthropic(api_key=api_key)
-    response = await client.messages.create(
-        model=SELECTION_MODEL_ANTHROPIC,
-        max_tokens=max_tokens,
-        system=system,
-        messages=[{"role": "user", "content": user}],
+    response = await call_with_retry(
+        lambda: client.messages.create(
+            model=SELECTION_MODEL_ANTHROPIC,
+            max_tokens=max_tokens,
+            system=system,
+            messages=[{"role": "user", "content": user}],
+        )
     )
     return response.content[0].text
 

--- a/inference/src/knowledge.py
+++ b/inference/src/knowledge.py
@@ -24,6 +24,12 @@ CHARS_PER_TOKEN = 4
 SELECTION_MODEL_GEMINI = "gemini-2.0-flash"
 SELECTION_MODEL_ANTHROPIC = "claude-haiku-4-5-20251001"
 
+# Token budgets for the two selector LLM calls.
+# Step 0 (summary) only needs 2-4 sentences; Step 1 (file selection) returns
+# a tiny JSON array. Keeping these tight shaves latency and cost.
+SUMMARY_MAX_TOKENS = 128
+SELECTION_MAX_TOKENS = 256
+
 
 # ── Index loading ──────────────────────────────────────────────────────────────
 
@@ -145,7 +151,7 @@ Rules:
 
 # ── LLM calls ─────────────────────────────────────────────────────────────────
 
-async def _call_gemini_selection(system: str, user: str) -> str:
+async def _call_gemini_selection(system: str, user: str, max_tokens: int) -> str:
     from google import genai
 
     api_key = os.environ.get("GEMINI_API_KEY")
@@ -156,30 +162,30 @@ async def _call_gemini_selection(system: str, user: str) -> str:
         config=genai.types.GenerateContentConfig(
             system_instruction=system,
             temperature=0.0,
-            max_output_tokens=256,
+            max_output_tokens=max_tokens,
         ),
     )
     return response.text or ""
 
 
-async def _call_anthropic_selection(system: str, user: str) -> str:
+async def _call_anthropic_selection(system: str, user: str, max_tokens: int) -> str:
     import anthropic
 
     api_key = os.environ.get("ANTHROPIC_API_KEY")
     client = anthropic.AsyncAnthropic(api_key=api_key)
     response = await client.messages.create(
         model=SELECTION_MODEL_ANTHROPIC,
-        max_tokens=256,
+        max_tokens=max_tokens,
         system=system,
         messages=[{"role": "user", "content": user}],
     )
     return response.content[0].text
 
 
-async def _call_selection_llm(system: str, user: str, provider: str) -> str:
+async def _call_selection_llm(system: str, user: str, provider: str, max_tokens: int) -> str:
     if provider == "ANTHROPIC":
-        return await _call_anthropic_selection(system, user)
-    return await _call_gemini_selection(system, user)
+        return await _call_anthropic_selection(system, user, max_tokens)
+    return await _call_gemini_selection(system, user, max_tokens)
 
 
 # ── Main public function ───────────────────────────────────────────────────────
@@ -211,6 +217,7 @@ async def pick_knowledge(
                 _get_summary_prompt(),
                 f"Conversation history:\n{history_text}",
                 provider,
+                SUMMARY_MAX_TOKENS,
             )
             conversation_summary = conversation_summary.strip() or "NONE"
         except Exception as e:
@@ -228,7 +235,9 @@ async def pick_knowledge(
 
     selected_names: list[str] = []
     try:
-        raw = await _call_selection_llm(selection_system, selection_user, provider)
+        raw = await _call_selection_llm(
+            selection_system, selection_user, provider, SELECTION_MAX_TOKENS
+        )
         # Extract JSON array from response (model may wrap it in markdown)
         match = re.search(r"\[.*?\]", raw, re.DOTALL)
         if match:

--- a/inference/src/providers/anthropic.py
+++ b/inference/src/providers/anthropic.py
@@ -1,6 +1,8 @@
 import os
 import anthropic
 
+from ..retry_utils import call_with_retry
+
 _api_key = os.environ.get("ANTHROPIC_API_KEY")
 _model = os.environ.get("ANTHROPIC_MODEL_NAME", "claude-haiku-4-5-20251001")
 _client = anthropic.AsyncAnthropic(api_key=_api_key)
@@ -21,11 +23,13 @@ async def generate(
     ]
     messages.append({"role": "user", "content": message})
 
-    response = await _client.messages.create(
-        model=_model,
-        max_tokens=1000,
-        system=system_prompt,
-        messages=messages,
+    response = await call_with_retry(
+        lambda: _client.messages.create(
+            model=_model,
+            max_tokens=1000,
+            system=system_prompt,
+            messages=messages,
+        )
     )
 
     return {

--- a/inference/src/providers/gemini.py
+++ b/inference/src/providers/gemini.py
@@ -1,6 +1,8 @@
 import os
 from google import genai
 
+from ..retry_utils import call_with_retry
+
 _api_key = os.environ.get("GEMINI_API_KEY")
 _model = os.environ.get("GEMINI_MODEL_NAME", "gemini-2.0-flash")
 _client = genai.Client(api_key=_api_key)
@@ -30,7 +32,7 @@ async def generate(
         ),
         history=history,
     )
-    response = await chat.send_message(message)
+    response = await call_with_retry(lambda: chat.send_message(message))
 
     return {
         "text": response.text,

--- a/inference/src/providers/gemini.py
+++ b/inference/src/providers/gemini.py
@@ -22,17 +22,25 @@ async def generate(
         for msg in conversation_history
     ]
 
-    chat = _client.aio.chats.create(
-        model=_model,
-        config=genai.types.GenerateContentConfig(
-            system_instruction=system_prompt,
-            temperature=0.7,
-            top_p=0.9,
-            max_output_tokens=8192,
-        ),
-        history=history,
-    )
-    response = await call_with_retry(lambda: chat.send_message(message))
+    # Recreate the chat object on every retry attempt. Reusing one chat
+    # across retries is unsafe: a partial failure may have already mutated
+    # the chat's internal turn list, so a retried send_message could double-
+    # append the user message or fail because the chat is in an unexpected
+    # state. The factory closure rebuilds chat + send_message each attempt.
+    def _attempt():
+        chat = _client.aio.chats.create(
+            model=_model,
+            config=genai.types.GenerateContentConfig(
+                system_instruction=system_prompt,
+                temperature=0.7,
+                top_p=0.9,
+                max_output_tokens=8192,
+            ),
+            history=history,
+        )
+        return chat.send_message(message)
+
+    response = await call_with_retry(_attempt)
 
     return {
         "text": response.text,

--- a/inference/src/retry_utils.py
+++ b/inference/src/retry_utils.py
@@ -1,0 +1,109 @@
+"""
+Shared retry policy for outbound LLM provider calls.
+
+Phase 2.3 of .plan/scaling-plan-100-concurrent-users.md: under high concurrency
+both Gemini and Anthropic surface transient 429s and 5xx. We retry those a
+small number of times with exponential backoff, but never retry on 4xx that
+indicate a permanent client problem (auth, malformed request).
+
+The decision to retry is based on inspecting an exception's HTTP status code
+where the provider SDKs expose one:
+
+  - anthropic: APIStatusError.status_code
+  - google.genai: errors.APIError.code
+
+plus a generic catch for connection-level / timeout exceptions which are
+always safe to retry.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from tenacity import (
+    AsyncRetrying,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential,
+    before_sleep_log,
+)
+
+logger = logging.getLogger(__name__)
+
+# HTTP statuses we treat as transient.
+_TRANSIENT_STATUSES = {408, 425, 429, 500, 502, 503, 504}
+
+# Default policy — small attempt count keeps worst-case latency bounded.
+DEFAULT_ATTEMPTS = 3
+DEFAULT_WAIT_INITIAL = 1.0
+DEFAULT_WAIT_MAX = 8.0
+
+
+def _extract_status(exc: BaseException) -> int | None:
+    """Pull an HTTP status code out of provider SDK exceptions if available."""
+    for attr in ("status_code", "code", "status"):
+        val = getattr(exc, attr, None)
+        if isinstance(val, int):
+            return val
+        # google.genai.errors.APIError exposes .code as int-ish
+        if isinstance(val, str) and val.isdigit():
+            return int(val)
+    # google.genai sometimes nests status under .response
+    response = getattr(exc, "response", None)
+    if response is not None:
+        sc = getattr(response, "status_code", None)
+        if isinstance(sc, int):
+            return sc
+    return None
+
+
+def _is_transient(exc: BaseException) -> bool:
+    # Connection-level / timeout exceptions: always retry. We test by class
+    # name to avoid hard-importing httpx / anthropic / google SDK error trees
+    # in this shared helper.
+    name = type(exc).__name__
+    if any(
+        token in name
+        for token in ("Timeout", "Connection", "APIConnection", "Network")
+    ):
+        return True
+
+    status = _extract_status(exc)
+    if status is None:
+        # Unknown error shape — do NOT retry. Surface it so we don't mask bugs.
+        return False
+    return status in _TRANSIENT_STATUSES
+
+
+def llm_retry(
+    attempts: int = DEFAULT_ATTEMPTS,
+    wait_initial: float = DEFAULT_WAIT_INITIAL,
+    wait_max: float = DEFAULT_WAIT_MAX,
+) -> AsyncRetrying:
+    """Build an AsyncRetrying configured for transient LLM API failures.
+
+    Usage:
+        async for attempt in llm_retry():
+            with attempt:
+                return await provider_call(...)
+    """
+    return AsyncRetrying(
+        stop=stop_after_attempt(attempts),
+        wait=wait_exponential(multiplier=wait_initial, max=wait_max),
+        retry=retry_if_exception(_is_transient),
+        before_sleep=before_sleep_log(logger, logging.WARNING),
+        reraise=True,
+    )
+
+
+async def call_with_retry(coro_factory: Any, **kwargs: Any) -> Any:
+    """Convenience wrapper: call `await coro_factory()` with the default policy.
+
+    `coro_factory` must be a zero-arg callable returning a coroutine, so each
+    retry attempt creates a fresh coroutine (coroutines can only be awaited
+    once).
+    """
+    async for attempt in llm_retry(**kwargs):
+        with attempt:
+            return await coro_factory()

--- a/inference/src/router.py
+++ b/inference/src/router.py
@@ -15,14 +15,56 @@ router = APIRouter()
 
 THERAPY_MODES = {"CBT", "MBT", "MBCT", "DBT"}
 
-# Phase 2.2 — bound the number of in-flight outbound LLM calls per worker
+# Phase 2.2 — bound the number of in-flight outbound LLM work per worker
 # process. Excess requests await the semaphore instead of fanning out and
 # tripping provider rate limits. With uvicorn workers=4 (Phase 1.4), the
 # effective ceiling is MAX_CONCURRENT_LLM_CALLS * 4. Tune via env.
-_MAX_CONCURRENT_LLM_CALLS = int(os.environ.get("MAX_CONCURRENT_LLM_CALLS", "20"))
+#
+# Scope: ONE acquire wraps the entire /generate request (Step 1 selector +
+# Step 2 generation). This caps in-flight *requests* rather than individual
+# LLM calls, which avoids the two-stage wave pattern where every request
+# clears Step 1 before any reaches Step 2. Trade-off: a request that would
+# fire 1-3 sequential LLM calls now holds one slot for the full duration,
+# so the env value should be tuned with that in mind.
+_DEFAULT_MAX_CONCURRENT_LLM_CALLS = 20
+
+
+def _resolve_max_concurrent_llm_calls() -> int:
+    """Parse MAX_CONCURRENT_LLM_CALLS from env, with safe fallbacks.
+
+    Bad / missing values fall back to the default rather than crashing app
+    startup or — worse — silently building a Semaphore(0) that deadlocks
+    every request.
+    """
+    raw = os.environ.get("MAX_CONCURRENT_LLM_CALLS")
+    if raw is None or raw == "":
+        return _DEFAULT_MAX_CONCURRENT_LLM_CALLS
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid MAX_CONCURRENT_LLM_CALLS=%r (not an integer); "
+            "falling back to default %d",
+            raw,
+            _DEFAULT_MAX_CONCURRENT_LLM_CALLS,
+        )
+        return _DEFAULT_MAX_CONCURRENT_LLM_CALLS
+    if value <= 0:
+        logger.warning(
+            "Non-positive MAX_CONCURRENT_LLM_CALLS=%r would deadlock the "
+            "endpoint; falling back to default %d",
+            raw,
+            _DEFAULT_MAX_CONCURRENT_LLM_CALLS,
+        )
+        return _DEFAULT_MAX_CONCURRENT_LLM_CALLS
+    return value
+
+
+_MAX_CONCURRENT_LLM_CALLS = _resolve_max_concurrent_llm_calls()
 _llm_semaphore = asyncio.Semaphore(_MAX_CONCURRENT_LLM_CALLS)
 logger.info(
-    f"LLM concurrency semaphore initialized: max={_MAX_CONCURRENT_LLM_CALLS} per worker"
+    f"LLM concurrency semaphore initialized: max={_MAX_CONCURRENT_LLM_CALLS} "
+    f"per worker (whole-request scope)"
 )
 
 
@@ -30,41 +72,45 @@ logger.info(
 async def generate(req: GenerateRequest) -> GenerateResponse:
     history = [{"role": m.role, "content": m.content} for m in req.conversation_history]
 
-    # Step 1: knowledge selection (skipped for INITIAL mode — no knowledge corpus yet)
-    knowledge_context = ""
-    if req.chatbot_type in THERAPY_MODES:
-        try:
-            async with _llm_semaphore:
+    # Single semaphore acquire wraps the entire request — Step 1 selector and
+    # Step 2 generation share one slot. `async with` guarantees the permit is
+    # released even on exceptions raised from either step.
+    async with _llm_semaphore:
+        # Step 1: knowledge selection (skipped for INITIAL mode — no corpus)
+        knowledge_context = ""
+        if req.chatbot_type in THERAPY_MODES:
+            try:
                 knowledge_context = await pick_knowledge(
                     chatbot_type=req.chatbot_type,
                     conversation_history=history,
                     message=req.message,
                     provider=req.provider,
                 )
-        except Exception as e:
-            logger.warning(f"Knowledge selection failed, proceeding without context: {e}")
+            except Exception as e:
+                logger.warning(
+                    f"Knowledge selection failed, proceeding without context: {e}"
+                )
 
-    # Build system prompt with optional knowledge context appended
-    system_prompt = get_system_prompt(req.chatbot_type, req.prompt_options)
-    if knowledge_context:
-        system_prompt = (
-            f"{system_prompt}\n\n"
-            f"**Reference Knowledge**\n"
-            f"The following summaries from therapy literature are relevant to this conversation. "
-            f"Use them to inform your approach, but do not reference them directly to the person.\n\n"
-            f"{knowledge_context}"
-        )
+        # Build system prompt with optional knowledge context appended
+        system_prompt = get_system_prompt(req.chatbot_type, req.prompt_options)
+        if knowledge_context:
+            system_prompt = (
+                f"{system_prompt}\n\n"
+                f"**Reference Knowledge**\n"
+                f"The following summaries from therapy literature are relevant to this conversation. "
+                f"Use them to inform your approach, but do not reference them directly to the person.\n\n"
+                f"{knowledge_context}"
+            )
 
-    # Step 2: therapy response generation
-    try:
-        async with _llm_semaphore:
+        # Step 2: therapy response generation
+        try:
             if req.provider == "ANTHROPIC":
                 result = await providers.anthropic.generate(system_prompt, history, req.message)
             else:
                 result = await providers.gemini.generate(system_prompt, history, req.message)
-    except Exception as e:
-        logger.error(f"Provider error: {e}")
-        raise HTTPException(status_code=502, detail=str(e))
+        except Exception as e:
+            logger.error(f"Provider error: {e}")
+            raise HTTPException(status_code=502, detail=str(e))
 
     return GenerateResponse(
         text=result["text"],

--- a/inference/src/router.py
+++ b/inference/src/router.py
@@ -1,4 +1,7 @@
+import asyncio
 import logging
+import os
+
 from fastapi import APIRouter, HTTPException
 
 from .models import GenerateRequest, GenerateResponse
@@ -12,6 +15,16 @@ router = APIRouter()
 
 THERAPY_MODES = {"CBT", "MBT", "MBCT", "DBT"}
 
+# Phase 2.2 — bound the number of in-flight outbound LLM calls per worker
+# process. Excess requests await the semaphore instead of fanning out and
+# tripping provider rate limits. With uvicorn workers=4 (Phase 1.4), the
+# effective ceiling is MAX_CONCURRENT_LLM_CALLS * 4. Tune via env.
+_MAX_CONCURRENT_LLM_CALLS = int(os.environ.get("MAX_CONCURRENT_LLM_CALLS", "20"))
+_llm_semaphore = asyncio.Semaphore(_MAX_CONCURRENT_LLM_CALLS)
+logger.info(
+    f"LLM concurrency semaphore initialized: max={_MAX_CONCURRENT_LLM_CALLS} per worker"
+)
+
 
 @router.post("/generate", response_model=GenerateResponse)
 async def generate(req: GenerateRequest) -> GenerateResponse:
@@ -21,12 +34,13 @@ async def generate(req: GenerateRequest) -> GenerateResponse:
     knowledge_context = ""
     if req.chatbot_type in THERAPY_MODES:
         try:
-            knowledge_context = await pick_knowledge(
-                chatbot_type=req.chatbot_type,
-                conversation_history=history,
-                message=req.message,
-                provider=req.provider,
-            )
+            async with _llm_semaphore:
+                knowledge_context = await pick_knowledge(
+                    chatbot_type=req.chatbot_type,
+                    conversation_history=history,
+                    message=req.message,
+                    provider=req.provider,
+                )
         except Exception as e:
             logger.warning(f"Knowledge selection failed, proceeding without context: {e}")
 
@@ -43,10 +57,11 @@ async def generate(req: GenerateRequest) -> GenerateResponse:
 
     # Step 2: therapy response generation
     try:
-        if req.provider == "ANTHROPIC":
-            result = await providers.anthropic.generate(system_prompt, history, req.message)
-        else:
-            result = await providers.gemini.generate(system_prompt, history, req.message)
+        async with _llm_semaphore:
+            if req.provider == "ANTHROPIC":
+                result = await providers.anthropic.generate(system_prompt, history, req.message)
+            else:
+                result = await providers.gemini.generate(system_prompt, history, req.message)
     except Exception as e:
         logger.error(f"Provider error: {e}")
         raise HTTPException(status_code=502, detail=str(e))

--- a/inference/tests/test_retry_utils.py
+++ b/inference/tests/test_retry_utils.py
@@ -1,0 +1,103 @@
+"""
+Unit tests for inference/src/retry_utils.py — verifies the transient-vs-permanent
+classifier and that call_with_retry reissues the coroutine on transient failures.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import unittest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_INFERENCE_ROOT = os.path.dirname(_HERE)
+if _INFERENCE_ROOT not in sys.path:
+    sys.path.insert(0, _INFERENCE_ROOT)
+
+from src import retry_utils  # noqa: E402
+
+
+class _FakeStatusError(Exception):
+    def __init__(self, status_code: int):
+        super().__init__(f"status {status_code}")
+        self.status_code = status_code
+
+
+class _FakeConnectionError(Exception):
+    """Class name contains 'Connection' so the heuristic flags it transient."""
+
+
+class _FakePermanentError(Exception):
+    """Generic exception with no status — must NOT retry."""
+
+
+class IsTransientTests(unittest.TestCase):
+    def test_429_is_transient(self):
+        self.assertTrue(retry_utils._is_transient(_FakeStatusError(429)))
+
+    def test_503_is_transient(self):
+        self.assertTrue(retry_utils._is_transient(_FakeStatusError(503)))
+
+    def test_400_is_not_transient(self):
+        self.assertFalse(retry_utils._is_transient(_FakeStatusError(400)))
+
+    def test_401_is_not_transient(self):
+        self.assertFalse(retry_utils._is_transient(_FakeStatusError(401)))
+
+    def test_connection_error_class_name_is_transient(self):
+        self.assertTrue(retry_utils._is_transient(_FakeConnectionError("boom")))
+
+    def test_unknown_exception_is_not_retried(self):
+        self.assertFalse(retry_utils._is_transient(_FakePermanentError("boom")))
+
+
+class CallWithRetryTests(unittest.TestCase):
+    def test_retries_then_succeeds_on_transient(self):
+        attempts = {"n": 0}
+
+        async def factory():
+            attempts["n"] += 1
+            if attempts["n"] < 3:
+                raise _FakeStatusError(503)
+            return "ok"
+
+        result = asyncio.run(
+            retry_utils.call_with_retry(factory, attempts=5, wait_initial=0.0, wait_max=0.0)
+        )
+        self.assertEqual(result, "ok")
+        self.assertEqual(attempts["n"], 3)
+
+    def test_does_not_retry_permanent(self):
+        attempts = {"n": 0}
+
+        async def factory():
+            attempts["n"] += 1
+            raise _FakeStatusError(400)
+
+        with self.assertRaises(_FakeStatusError):
+            asyncio.run(
+                retry_utils.call_with_retry(
+                    factory, attempts=5, wait_initial=0.0, wait_max=0.0
+                )
+            )
+        self.assertEqual(attempts["n"], 1)
+
+    def test_gives_up_after_attempts(self):
+        attempts = {"n": 0}
+
+        async def factory():
+            attempts["n"] += 1
+            raise _FakeStatusError(429)
+
+        with self.assertRaises(_FakeStatusError):
+            asyncio.run(
+                retry_utils.call_with_retry(
+                    factory, attempts=2, wait_initial=0.0, wait_max=0.0
+                )
+            )
+        self.assertEqual(attempts["n"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/inference/tests/test_router_semaphore.py
+++ b/inference/tests/test_router_semaphore.py
@@ -1,0 +1,143 @@
+"""
+Unit tests for inference/src/router.py — focused on the Phase 2.2
+concurrency semaphore configuration and runtime behavior.
+
+These tests do NOT require a running FastAPI app or any LLM SDKs; they
+exercise the env-parsing helper directly and verify the semaphore's
+acquire/release lifecycle (including correct release on exception).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import types
+import unittest
+from unittest import mock
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_INFERENCE_ROOT = os.path.dirname(_HERE)
+if _INFERENCE_ROOT not in sys.path:
+    sys.path.insert(0, _INFERENCE_ROOT)
+
+# Stub provider SDKs so this test runs without google-genai / anthropic
+# installed. router imports `from . import providers`, which imports both.
+def _install_stub(modname: str, attrs: dict | None = None) -> None:
+    mod = types.ModuleType(modname)
+    for k, v in (attrs or {}).items():
+        setattr(mod, k, v)
+    sys.modules[modname] = mod
+
+if "google" not in sys.modules:
+    _install_stub("google")
+if "google.genai" not in sys.modules:
+    genai_stub = types.ModuleType("google.genai")
+    genai_stub.types = types.SimpleNamespace(
+        Content=lambda **kw: kw,
+        Part=lambda **kw: kw,
+        GenerateContentConfig=lambda **kw: kw,
+    )
+    genai_stub.Client = lambda **kw: types.SimpleNamespace(
+        aio=types.SimpleNamespace(
+            chats=types.SimpleNamespace(create=lambda **k: None),
+            models=types.SimpleNamespace(generate_content=lambda **k: None),
+        )
+    )
+    sys.modules["google.genai"] = genai_stub
+    sys.modules["google"].genai = genai_stub  # type: ignore[attr-defined]
+if "anthropic" not in sys.modules:
+    anthropic_stub = types.ModuleType("anthropic")
+    anthropic_stub.AsyncAnthropic = lambda **kw: types.SimpleNamespace(
+        messages=types.SimpleNamespace(create=lambda **k: None)
+    )
+    sys.modules["anthropic"] = anthropic_stub
+if "frontmatter" not in sys.modules:
+    fm = types.ModuleType("frontmatter")
+    fm.load = lambda path: types.SimpleNamespace(metadata={}, content="")
+    sys.modules["frontmatter"] = fm
+
+from src import router  # noqa: E402
+
+
+class ResolveMaxConcurrentTests(unittest.TestCase):
+    """The env-parsing helper must never produce a deadlocking value."""
+
+    def _resolve(self, value):
+        env = {} if value is None else {"MAX_CONCURRENT_LLM_CALLS": value}
+        with mock.patch.dict(os.environ, env, clear=False):
+            if value is None:
+                os.environ.pop("MAX_CONCURRENT_LLM_CALLS", None)
+            return router._resolve_max_concurrent_llm_calls()
+
+    def test_default_when_unset(self):
+        self.assertEqual(self._resolve(None), router._DEFAULT_MAX_CONCURRENT_LLM_CALLS)
+
+    def test_default_when_empty_string(self):
+        self.assertEqual(self._resolve(""), router._DEFAULT_MAX_CONCURRENT_LLM_CALLS)
+
+    def test_valid_positive_int(self):
+        self.assertEqual(self._resolve("42"), 42)
+
+    def test_non_integer_falls_back(self):
+        self.assertEqual(self._resolve("foo"), router._DEFAULT_MAX_CONCURRENT_LLM_CALLS)
+
+    def test_zero_falls_back_to_avoid_deadlock(self):
+        # A literal Semaphore(0) would silently hang every request forever.
+        self.assertEqual(self._resolve("0"), router._DEFAULT_MAX_CONCURRENT_LLM_CALLS)
+
+    def test_negative_falls_back(self):
+        self.assertEqual(self._resolve("-1"), router._DEFAULT_MAX_CONCURRENT_LLM_CALLS)
+
+    def test_float_string_falls_back(self):
+        self.assertEqual(self._resolve("2.5"), router._DEFAULT_MAX_CONCURRENT_LLM_CALLS)
+
+
+class SemaphoreReleaseTests(unittest.TestCase):
+    """The semaphore must release the permit even when the body raises."""
+
+    def test_permit_released_on_exception(self):
+        async def scenario():
+            sem = asyncio.Semaphore(1)
+
+            async def body_raises():
+                async with sem:
+                    raise RuntimeError("boom")
+
+            with self.assertRaises(RuntimeError):
+                await body_raises()
+
+            # If the permit leaked we would deadlock on this acquire under
+            # wait_for; the timeout proves release happened.
+            await asyncio.wait_for(sem.acquire(), timeout=0.5)
+            sem.release()
+
+        asyncio.run(scenario())
+
+    def test_concurrent_requests_are_capped(self):
+        """With Semaphore(2), only 2 of 5 coroutines run inside the body at once."""
+        async def scenario():
+            sem = asyncio.Semaphore(2)
+            inside = 0
+            peak = 0
+            lock = asyncio.Lock()
+
+            async def worker():
+                nonlocal inside, peak
+                async with sem:
+                    async with lock:
+                        inside += 1
+                        peak = max(peak, inside)
+                    await asyncio.sleep(0.02)
+                    async with lock:
+                        inside -= 1
+
+            await asyncio.gather(*(worker() for _ in range(5)))
+            return peak
+
+        peak = asyncio.run(scenario())
+        self.assertLessEqual(peak, 2, f"semaphore allowed {peak} concurrent (>2)")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Implements the first three Phase 2 items from `.plan/scaling-plan-100-concurrent-users.md` to harden the inference layer for high concurrency.

### Changes
- **2.1** Tighten knowledge-selector summary budget to 128 tokens; introduce `SUMMARY_MAX_TOKENS` / `SELECTION_MAX_TOKENS` constants.
- **2.3** New `retry_utils.py` — tenacity exponential backoff (3 attempts, 1–8s) on 408/425/429/5xx and connection errors only; 4xx never retried. Applied to both providers and the selector. Gemini chat object rebuilt per attempt to avoid state corruption.
- **2.2** Router-level `asyncio.Semaphore` (env `MAX_CONCURRENT_LLM_CALLS`, default 20, per-worker) acquired once around the full request lifecycle. Env parsing falls back safely on non-integer / non-positive values to avoid startup crashes and `Semaphore(0)` deadlocks.

### Tests
22/22 new unit tests pass (knowledge 4 + retry 9 + router semaphore 9). `docker-compose.prod.yml` surfaces `MAX_CONCURRENT_LLM_CALLS=20`.